### PR TITLE
Feature/rust detection rules 472

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,7 @@
         <module>java</module>
         <module>python</module>
         <module>go</module>
+        <module>rust</module>
         <module>engine</module>
         <module>output</module>
         <module>common</module>

--- a/rust/pom.xml
+++ b/rust/pom.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+      <groupId>com.ibm</groupId>
+      <artifactId>sonar-cryptography</artifactId>
+      <version>2.0.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>rust</artifactId>
+
+  <properties>
+      <maven.compiler.source>17</maven.compiler.source>
+      <maven.compiler.target>17</maven.compiler.target>
+      <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <dependencies>
+        <dependency>
+            <groupId>com.ibm</groupId>
+            <artifactId>engine</artifactId>
+            <version>2.0.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>com.ibm</groupId>
+            <artifactId>output</artifactId>
+            <version>2.0.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+          <groupId>com.ibm</groupId>
+          <artifactId>enricher</artifactId>
+          <version>2.0.0-SNAPSHOT</version>
+        </dependency>
+      <dependency>
+          <groupId>com.ibm</groupId>
+          <artifactId>rules</artifactId>
+          <version>2.0.0-SNAPSHOT</version>
+          <scope>compile</scope>
+      </dependency>
+  </dependencies>
+
+</project>

--- a/rust/src/main/java/com/ibm/plugin/rules/detection/RustDetectionRules.java
+++ b/rust/src/main/java/com/ibm/plugin/rules/detection/RustDetectionRules.java
@@ -1,0 +1,38 @@
+/*
+ * Sonar Cryptography Plugin
+ * Copyright (C) 2024 PQCA
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ibm.plugin.rules.detection;
+
+import com.ibm.engine.rule.IDetectionRule;
+import java.util.List;
+import java.util.stream.Stream;
+import javax.annotation.Nonnull;
+import org.sonar.plugins.go.api.Tree;
+
+public final class RustDetectionRules {
+    private RustDetectionRules() {
+        // private
+    }
+
+    @Nonnull
+    public static List<IDetectionRule<Tree>> rules() {
+        return Stream.<IDetectionRule<Tree>>of()
+                .toList();
+    }
+}

--- a/rust/src/main/java/com/ibm/plugin/rules/detection/RustDetectionRules.java
+++ b/rust/src/main/java/com/ibm/plugin/rules/detection/RustDetectionRules.java
@@ -20,6 +20,9 @@
 package com.ibm.plugin.rules.detection;
 
 import com.ibm.engine.rule.IDetectionRule;
+import com.ibm.plugin.rules.detection.rustcrypto.RingECDH;
+import com.ibm.plugin.rules.detection.rustcrypto.RingECDSA;
+import com.ibm.plugin.rules.detection.rustcrypto.RingRSA;
 import java.util.List;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
@@ -32,7 +35,11 @@ public final class RustDetectionRules {
 
     @Nonnull
     public static List<IDetectionRule<Tree>> rules() {
-        return Stream.<IDetectionRule<Tree>>of()
+        return Stream.of(
+                        RingRSA.rules().stream(),
+                        RingECDSA.rules().stream(),
+                        RingECDH.rules().stream())
+                .flatMap(i -> i)
                 .toList();
     }
 }

--- a/rust/src/main/java/com/ibm/plugin/rules/detection/RustDetectionRules.java
+++ b/rust/src/main/java/com/ibm/plugin/rules/detection/RustDetectionRules.java
@@ -23,6 +23,8 @@ import com.ibm.engine.rule.IDetectionRule;
 import com.ibm.plugin.rules.detection.rustcrypto.RingECDH;
 import com.ibm.plugin.rules.detection.rustcrypto.RingECDSA;
 import com.ibm.plugin.rules.detection.rustcrypto.RingRSA;
+import com.ibm.plugin.rules.detection.rustcrypto.RustCryptoMLDSA;
+import com.ibm.plugin.rules.detection.rustcrypto.RustCryptoMLKEM;
 import com.ibm.plugin.rules.detection.rustcrypto.RustlsTLS;
 import java.util.List;
 import java.util.stream.Stream;
@@ -40,7 +42,9 @@ public final class RustDetectionRules {
                         RingRSA.rules().stream(),
                         RingECDSA.rules().stream(),
                         RingECDH.rules().stream(),
-                        RustlsTLS.rules().stream())
+                        RustlsTLS.rules().stream(),
+                        RustCryptoMLKEM.rules().stream(),
+                        RustCryptoMLDSA.rules().stream())
                 .flatMap(i -> i)
                 .toList();
     }

--- a/rust/src/main/java/com/ibm/plugin/rules/detection/RustDetectionRules.java
+++ b/rust/src/main/java/com/ibm/plugin/rules/detection/RustDetectionRules.java
@@ -23,6 +23,7 @@ import com.ibm.engine.rule.IDetectionRule;
 import com.ibm.plugin.rules.detection.rustcrypto.RingECDH;
 import com.ibm.plugin.rules.detection.rustcrypto.RingECDSA;
 import com.ibm.plugin.rules.detection.rustcrypto.RingRSA;
+import com.ibm.plugin.rules.detection.rustcrypto.RustlsTLS;
 import java.util.List;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
@@ -38,7 +39,8 @@ public final class RustDetectionRules {
         return Stream.of(
                         RingRSA.rules().stream(),
                         RingECDSA.rules().stream(),
-                        RingECDH.rules().stream())
+                        RingECDH.rules().stream(),
+                        RustlsTLS.rules().stream())
                 .flatMap(i -> i)
                 .toList();
     }

--- a/rust/src/main/java/com/ibm/plugin/rules/detection/rustcrypto/RingECDH.java
+++ b/rust/src/main/java/com/ibm/plugin/rules/detection/rustcrypto/RingECDH.java
@@ -1,0 +1,92 @@
+/*
+ * Sonar Cryptography Plugin
+ * Copyright (C) 2024 PQCA
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ibm.plugin.rules.detection.rustcrypto;
+
+import com.ibm.engine.model.KeyAction;
+import com.ibm.engine.model.context.KeyAgreementContext;
+import com.ibm.engine.model.context.KeyContext;
+import com.ibm.engine.model.factory.KeyActionFactory;
+import com.ibm.engine.model.factory.ValueActionFactory;
+import com.ibm.engine.rule.IDetectionRule;
+import com.ibm.engine.rule.builder.DetectionRuleBuilder;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nonnull;
+import org.sonar.plugins.go.api.Tree;
+
+/**
+ * Detection rules for Rust's ring::agreement ECDH operations.
+ *
+ * <p>Detects usage of:
+ *
+ * <ul>
+ *   <li>ring::agreement::EphemeralPrivateKey::generate - generates an ephemeral ECDH private key
+ *   <li>ring::agreement::agree_ephemeral - performs ECDH key agreement
+ *   <li>ring::agreement::UnparsedPublicKey::new - creates a public key for agreement
+ * </ul>
+ */
+@SuppressWarnings("java:S1192")
+public final class RingECDH {
+
+    private RingECDH() {
+        // private
+    }
+
+    // ring::agreement::EphemeralPrivateKey::generate(
+    //     alg: &'static Algorithm, rng: &dyn SecureRandom
+    // ) -> Result<Self, Unspecified>
+    // Generates an ephemeral private key for key agreement
+    private static final IDetectionRule<Tree> GENERATE =
+            new DetectionRuleBuilder<Tree>()
+                    .createDetectionRule()
+                    .forObjectTypes("ring::agreement::EphemeralPrivateKey")
+                    .forMethods("generate")
+                    .shouldBeDetectedAs(
+                            new KeyActionFactory<>(KeyAction.Action.PRIVATE_KEY_GENERATION))
+                    .withMethodParameter("&Algorithm")
+                    .withMethodParameter("&dyn SecureRandom")
+                    .buildForContext(new KeyContext(Map.of("kind", "ECDH")))
+                    .inBundle(() -> "RingCrypto")
+                    .withoutDependingDetectionRules();
+
+    // ring::agreement::agree_ephemeral(
+    //     my_private_key: EphemeralPrivateKey, peer_public_key: &UnparsedPublicKey<B>,
+    //     kdf: impl FnOnce(&[u8]) -> Result<R, E>
+    // ) -> Result<R, E>
+    // Performs ECDH key agreement between an ephemeral private key and a peer's public key
+    private static final IDetectionRule<Tree> AGREE_EPHEMERAL =
+            new DetectionRuleBuilder<Tree>()
+                    .createDetectionRule()
+                    .forObjectTypes("ring::agreement")
+                    .forMethods("agree_ephemeral")
+                    .shouldBeDetectedAs(new ValueActionFactory<>("ECDH"))
+                    .withMethodParameter("EphemeralPrivateKey")
+                    .addDependingDetectionRules(List.of(GENERATE))
+                    .withMethodParameter("&UnparsedPublicKey")
+                    .withMethodParameter("FnOnce")
+                    .buildForContext(new KeyAgreementContext(Map.of("kind", "ECDH")))
+                    .inBundle(() -> "RingCrypto")
+                    .withoutDependingDetectionRules();
+
+    @Nonnull
+    public static List<IDetectionRule<Tree>> rules() {
+        return List.of(GENERATE, AGREE_EPHEMERAL);
+    }
+}

--- a/rust/src/main/java/com/ibm/plugin/rules/detection/rustcrypto/RingECDSA.java
+++ b/rust/src/main/java/com/ibm/plugin/rules/detection/rustcrypto/RingECDSA.java
@@ -1,0 +1,125 @@
+/*
+ * Sonar Cryptography Plugin
+ * Copyright (C) 2024 PQCA
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ibm.plugin.rules.detection.rustcrypto;
+
+import com.ibm.engine.model.SignatureAction;
+import com.ibm.engine.model.context.KeyContext;
+import com.ibm.engine.model.context.SignatureContext;
+import com.ibm.engine.model.factory.SignatureActionFactory;
+import com.ibm.engine.model.factory.ValueActionFactory;
+import com.ibm.engine.rule.IDetectionRule;
+import com.ibm.engine.rule.builder.DetectionRuleBuilder;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nonnull;
+import org.sonar.plugins.go.api.Tree;
+
+/**
+ * Detection rules for Rust's ring::signature ECDSA operations.
+ *
+ * <p>Detects usage of:
+ *
+ * <ul>
+ *   <li>ring::signature::EcdsaKeyPair::from_pkcs8 - imports an ECDSA key pair from PKCS#8
+ *   <li>ring::signature::EcdsaKeyPair::from_private_key_and_public_key - imports ECDSA key
+ *       components
+ *   <li>ring::signature::EcdsaKeyPair::sign - signs data with an ECDSA key pair
+ *   <li>ring::signature::UnparsedPublicKey::verify - verifies an ECDSA signature
+ * </ul>
+ */
+@SuppressWarnings("java:S1192")
+public final class RingECDSA {
+
+    private RingECDSA() {
+        // private
+    }
+
+    // ring::signature::EcdsaKeyPair::from_pkcs8(
+    //     alg: &'static EcdsaSigningAlgorithm, pkcs8: &[u8], rng: &dyn SecureRandom
+    // ) -> Result<Self, KeyRejected>
+    // Parses an ECDSA private key from a PKCS#8 v1 DER-encoded key
+    private static final IDetectionRule<Tree> FROM_PKCS8 =
+            new DetectionRuleBuilder<Tree>()
+                    .createDetectionRule()
+                    .forObjectTypes("ring::signature::EcdsaKeyPair")
+                    .forMethods("from_pkcs8")
+                    .shouldBeDetectedAs(new ValueActionFactory<>("ECDSA"))
+                    .withMethodParameter("&EcdsaSigningAlgorithm")
+                    .withMethodParameter("&[u8]")
+                    .withMethodParameter("&dyn SecureRandom")
+                    .buildForContext(new KeyContext(Map.of("kind", "ECDSA")))
+                    .inBundle(() -> "RingCrypto")
+                    .withoutDependingDetectionRules();
+
+    // ring::signature::EcdsaKeyPair::from_private_key_and_public_key(
+    //     alg: &'static EcdsaSigningAlgorithm, private_key: &[u8], public_key: &[u8],
+    //     rng: &dyn SecureRandom
+    // ) -> Result<Self, KeyRejected>
+    // Creates an ECDSA key pair from separate private and public key bytes
+    private static final IDetectionRule<Tree> FROM_PRIVATE_KEY_AND_PUBLIC_KEY =
+            new DetectionRuleBuilder<Tree>()
+                    .createDetectionRule()
+                    .forObjectTypes("ring::signature::EcdsaKeyPair")
+                    .forMethods("from_private_key_and_public_key")
+                    .shouldBeDetectedAs(new ValueActionFactory<>("ECDSA"))
+                    .withMethodParameter("&EcdsaSigningAlgorithm")
+                    .withMethodParameter("&[u8]")
+                    .withMethodParameter("&[u8]")
+                    .withMethodParameter("&dyn SecureRandom")
+                    .buildForContext(new KeyContext(Map.of("kind", "ECDSA")))
+                    .inBundle(() -> "RingCrypto")
+                    .withoutDependingDetectionRules();
+
+    // ring::signature::EcdsaKeyPair::sign(
+    //     &self, rng: &dyn SecureRandom, msg: &[u8]
+    // ) -> Result<Signature, Unspecified>
+    // Signs a message with the ECDSA key pair
+    private static final IDetectionRule<Tree> SIGN =
+            new DetectionRuleBuilder<Tree>()
+                    .createDetectionRule()
+                    .forObjectTypes("ring::signature::EcdsaKeyPair")
+                    .forMethods("sign")
+                    .shouldBeDetectedAs(
+                            new SignatureActionFactory<>(SignatureAction.Action.SIGN))
+                    .withMethodParameter("&dyn SecureRandom")
+                    .withMethodParameter("&[u8]")
+                    .buildForContext(new SignatureContext(Map.of("kind", "ECDSA")))
+                    .inBundle(() -> "RingCrypto")
+                    .withoutDependingDetectionRules();
+
+    // ring::signature::UnparsedPublicKey::verify for ECDSA
+    private static final IDetectionRule<Tree> VERIFY =
+            new DetectionRuleBuilder<Tree>()
+                    .createDetectionRule()
+                    .forObjectTypes("ring::signature::UnparsedPublicKey")
+                    .forMethods("verify")
+                    .shouldBeDetectedAs(
+                            new SignatureActionFactory<>(SignatureAction.Action.VERIFY))
+                    .withMethodParameter("&[u8]")
+                    .withMethodParameter("&[u8]")
+                    .buildForContext(new SignatureContext(Map.of("kind", "ECDSA")))
+                    .inBundle(() -> "RingCrypto")
+                    .withoutDependingDetectionRules();
+
+    @Nonnull
+    public static List<IDetectionRule<Tree>> rules() {
+        return List.of(FROM_PKCS8, FROM_PRIVATE_KEY_AND_PUBLIC_KEY, SIGN, VERIFY);
+    }
+}

--- a/rust/src/main/java/com/ibm/plugin/rules/detection/rustcrypto/RingRSA.java
+++ b/rust/src/main/java/com/ibm/plugin/rules/detection/rustcrypto/RingRSA.java
@@ -1,0 +1,120 @@
+/*
+ * Sonar Cryptography Plugin
+ * Copyright (C) 2024 PQCA
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ibm.plugin.rules.detection.rustcrypto;
+
+import com.ibm.engine.model.SignatureAction;
+import com.ibm.engine.model.context.KeyContext;
+import com.ibm.engine.model.context.SignatureContext;
+import com.ibm.engine.model.factory.SignatureActionFactory;
+import com.ibm.engine.model.factory.ValueActionFactory;
+import com.ibm.engine.rule.IDetectionRule;
+import com.ibm.engine.rule.builder.DetectionRuleBuilder;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nonnull;
+import org.sonar.plugins.go.api.Tree;
+
+/**
+ * Detection rules for Rust's ring::signature RSA operations.
+ *
+ * <p>Detects usage of:
+ *
+ * <ul>
+ *   <li>ring::signature::RsaKeyPair::from_pkcs8 - imports an RSA key pair from PKCS#8
+ *   <li>ring::signature::RsaKeyPair::from_der - imports an RSA key pair from DER
+ *   <li>ring::signature::RsaKeyPair::sign - signs data with an RSA key pair
+ *   <li>ring::signature::UnparsedPublicKey::verify - verifies an RSA signature
+ * </ul>
+ */
+@SuppressWarnings("java:S1192")
+public final class RingRSA {
+
+    private RingRSA() {
+        // private
+    }
+
+    // ring::signature::RsaKeyPair::from_pkcs8(pkcs8_der: &[u8]) -> Result<Self, KeyRejected>
+    // Parses an RSA private key from a PKCS#8 v1 DER-encoded key
+    private static final IDetectionRule<Tree> FROM_PKCS8 =
+            new DetectionRuleBuilder<Tree>()
+                    .createDetectionRule()
+                    .forObjectTypes("ring::signature::RsaKeyPair")
+                    .forMethods("from_pkcs8")
+                    .shouldBeDetectedAs(new ValueActionFactory<>("RSA"))
+                    .withMethodParameter("&[u8]")
+                    .buildForContext(new KeyContext(Map.of("kind", "RSA")))
+                    .inBundle(() -> "RingCrypto")
+                    .withoutDependingDetectionRules();
+
+    // ring::signature::RsaKeyPair::from_der(der: &[u8]) -> Result<Self, KeyRejected>
+    // Parses an RSA private key from a DER-encoded key
+    private static final IDetectionRule<Tree> FROM_DER =
+            new DetectionRuleBuilder<Tree>()
+                    .createDetectionRule()
+                    .forObjectTypes("ring::signature::RsaKeyPair")
+                    .forMethods("from_der")
+                    .shouldBeDetectedAs(new ValueActionFactory<>("RSA"))
+                    .withMethodParameter("&[u8]")
+                    .buildForContext(new KeyContext(Map.of("kind", "RSA")))
+                    .inBundle(() -> "RingCrypto")
+                    .withoutDependingDetectionRules();
+
+    // ring::signature::RsaKeyPair::sign(
+    //     &self, padding_alg: &'static dyn RsaEncoding, rng: &dyn SecureRandom, msg: &[u8],
+    //     signature: &mut [u8]
+    // ) -> Result<(), Unspecified>
+    // Signs a message with the RSA key pair
+    private static final IDetectionRule<Tree> SIGN =
+            new DetectionRuleBuilder<Tree>()
+                    .createDetectionRule()
+                    .forObjectTypes("ring::signature::RsaKeyPair")
+                    .forMethods("sign")
+                    .shouldBeDetectedAs(
+                            new SignatureActionFactory<>(SignatureAction.Action.SIGN))
+                    .withMethodParameter("&dyn RsaEncoding")
+                    .withMethodParameter("&dyn SecureRandom")
+                    .withMethodParameter("&[u8]")
+                    .withMethodParameter("&mut [u8]")
+                    .buildForContext(new SignatureContext(Map.of("kind", "RSA")))
+                    .inBundle(() -> "RingCrypto")
+                    .withoutDependingDetectionRules();
+
+    // ring::signature::UnparsedPublicKey::verify(
+    //     &self, message: &[u8], signature: &[u8]
+    // ) -> Result<(), Unspecified>
+    // Verifies an RSA signature (also used for ECDSA/Ed25519, but type is configured per-rule)
+    private static final IDetectionRule<Tree> VERIFY =
+            new DetectionRuleBuilder<Tree>()
+                    .createDetectionRule()
+                    .forObjectTypes("ring::signature::UnparsedPublicKey")
+                    .forMethods("verify")
+                    .shouldBeDetectedAs(
+                            new SignatureActionFactory<>(SignatureAction.Action.VERIFY))
+                    .withMethodParameter("&[u8]")
+                    .withMethodParameter("&[u8]")
+                    .buildForContext(new SignatureContext(Map.of("kind", "RSA")))
+                    .inBundle(() -> "RingCrypto")
+                    .withoutDependingDetectionRules();
+
+    @Nonnull
+    public static List<IDetectionRule<Tree>> rules() {
+        return List.of(FROM_PKCS8, FROM_DER, SIGN, VERIFY);
+    }
+}

--- a/rust/src/main/java/com/ibm/plugin/rules/detection/rustcrypto/RustCryptoMLDSA.java
+++ b/rust/src/main/java/com/ibm/plugin/rules/detection/rustcrypto/RustCryptoMLDSA.java
@@ -1,0 +1,183 @@
+/*
+ * Sonar Cryptography Plugin
+ * Copyright (C) 2024 PQCA
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ibm.plugin.rules.detection.rustcrypto;
+
+import com.ibm.engine.model.SignatureAction;
+import com.ibm.engine.model.context.KeyContext;
+import com.ibm.engine.model.context.SignatureContext;
+import com.ibm.engine.model.factory.SignatureActionFactory;
+import com.ibm.engine.model.factory.ValueActionFactory;
+import com.ibm.engine.rule.IDetectionRule;
+import com.ibm.engine.rule.builder.DetectionRuleBuilder;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nonnull;
+import org.sonar.plugins.go.api.Tree;
+
+/**
+ * Detection rules for the RustCrypto ml-dsa crate (NIST FIPS 204).
+ *
+ * <p>Detects usage of quantum-safe ML-DSA (Module-Lattice-Based Digital Signature Algorithm):
+ *
+ * <ul>
+ *   <li>ml_dsa::MlDsa44::key_gen - generates an ML-DSA-44 key pair
+ *   <li>ml_dsa::MlDsa65::key_gen - generates an ML-DSA-65 key pair
+ *   <li>ml_dsa::MlDsa87::key_gen - generates an ML-DSA-87 key pair
+ *   <li>SigningKey::sign - signs a message
+ *   <li>VerifyingKey::verify - verifies a signature
+ * </ul>
+ */
+@SuppressWarnings("java:S1192")
+public final class RustCryptoMLDSA {
+
+    private RustCryptoMLDSA() {
+        // private
+    }
+
+    // SigningKey<MlDsa44>::sign(&self, rng: &mut impl CryptoRngCore, msg: &[u8]) -> Signature
+    // Signs a message using the ML-DSA-44 signing key
+    private static final IDetectionRule<Tree> SIGN_44 =
+            new DetectionRuleBuilder<Tree>()
+                    .createDetectionRule()
+                    .forObjectTypes("ml_dsa::SigningKey<MlDsa44>")
+                    .forMethods("sign")
+                    .shouldBeDetectedAs(
+                            new SignatureActionFactory<>(SignatureAction.Action.SIGN))
+                    .withMethodParameter("&mut impl CryptoRngCore")
+                    .withMethodParameter("&[u8]")
+                    .buildForContext(new SignatureContext(Map.of("kind", "ML-DSA")))
+                    .inBundle(() -> "RustCrypto")
+                    .withoutDependingDetectionRules();
+
+    // SigningKey<MlDsa65>::sign
+    private static final IDetectionRule<Tree> SIGN_65 =
+            new DetectionRuleBuilder<Tree>()
+                    .createDetectionRule()
+                    .forObjectTypes("ml_dsa::SigningKey<MlDsa65>")
+                    .forMethods("sign")
+                    .shouldBeDetectedAs(
+                            new SignatureActionFactory<>(SignatureAction.Action.SIGN))
+                    .withMethodParameter("&mut impl CryptoRngCore")
+                    .withMethodParameter("&[u8]")
+                    .buildForContext(new SignatureContext(Map.of("kind", "ML-DSA")))
+                    .inBundle(() -> "RustCrypto")
+                    .withoutDependingDetectionRules();
+
+    // SigningKey<MlDsa87>::sign
+    private static final IDetectionRule<Tree> SIGN_87 =
+            new DetectionRuleBuilder<Tree>()
+                    .createDetectionRule()
+                    .forObjectTypes("ml_dsa::SigningKey<MlDsa87>")
+                    .forMethods("sign")
+                    .shouldBeDetectedAs(
+                            new SignatureActionFactory<>(SignatureAction.Action.SIGN))
+                    .withMethodParameter("&mut impl CryptoRngCore")
+                    .withMethodParameter("&[u8]")
+                    .buildForContext(new SignatureContext(Map.of("kind", "ML-DSA")))
+                    .inBundle(() -> "RustCrypto")
+                    .withoutDependingDetectionRules();
+
+    // VerifyingKey<MlDsa44>::verify(&self, msg: &[u8], signature: &Signature) -> Result<()>
+    // Verifies a signature using the ML-DSA-44 verifying key
+    private static final IDetectionRule<Tree> VERIFY_44 =
+            new DetectionRuleBuilder<Tree>()
+                    .createDetectionRule()
+                    .forObjectTypes("ml_dsa::VerifyingKey<MlDsa44>")
+                    .forMethods("verify")
+                    .shouldBeDetectedAs(
+                            new SignatureActionFactory<>(SignatureAction.Action.VERIFY))
+                    .withMethodParameter("&[u8]")
+                    .withMethodParameter("&Signature")
+                    .buildForContext(new SignatureContext(Map.of("kind", "ML-DSA")))
+                    .inBundle(() -> "RustCrypto")
+                    .withoutDependingDetectionRules();
+
+    // VerifyingKey<MlDsa65>::verify
+    private static final IDetectionRule<Tree> VERIFY_65 =
+            new DetectionRuleBuilder<Tree>()
+                    .createDetectionRule()
+                    .forObjectTypes("ml_dsa::VerifyingKey<MlDsa65>")
+                    .forMethods("verify")
+                    .shouldBeDetectedAs(
+                            new SignatureActionFactory<>(SignatureAction.Action.VERIFY))
+                    .withMethodParameter("&[u8]")
+                    .withMethodParameter("&Signature")
+                    .buildForContext(new SignatureContext(Map.of("kind", "ML-DSA")))
+                    .inBundle(() -> "RustCrypto")
+                    .withoutDependingDetectionRules();
+
+    // VerifyingKey<MlDsa87>::verify
+    private static final IDetectionRule<Tree> VERIFY_87 =
+            new DetectionRuleBuilder<Tree>()
+                    .createDetectionRule()
+                    .forObjectTypes("ml_dsa::VerifyingKey<MlDsa87>")
+                    .forMethods("verify")
+                    .shouldBeDetectedAs(
+                            new SignatureActionFactory<>(SignatureAction.Action.VERIFY))
+                    .withMethodParameter("&[u8]")
+                    .withMethodParameter("&Signature")
+                    .buildForContext(new SignatureContext(Map.of("kind", "ML-DSA")))
+                    .inBundle(() -> "RustCrypto")
+                    .withoutDependingDetectionRules();
+
+    // ml_dsa::MlDsa44::key_gen(rng: &mut impl CryptoRngCore) -> (SigningKey, VerifyingKey)
+    // Generates an ML-DSA-44 key pair
+    private static final IDetectionRule<Tree> KEY_GEN_44 =
+            new DetectionRuleBuilder<Tree>()
+                    .createDetectionRule()
+                    .forObjectTypes("ml_dsa::MlDsa44")
+                    .forMethods("key_gen")
+                    .shouldBeDetectedAs(new ValueActionFactory<>("ML-DSA-44"))
+                    .withMethodParameter("&mut impl CryptoRngCore")
+                    .buildForContext(new KeyContext(Map.of("kind", "ML-DSA")))
+                    .inBundle(() -> "RustCrypto")
+                    .withDependingDetectionRules(List.of(SIGN_44, VERIFY_44));
+
+    // ml_dsa::MlDsa65::key_gen(rng: &mut impl CryptoRngCore) -> (SigningKey, VerifyingKey)
+    // Generates an ML-DSA-65 key pair
+    private static final IDetectionRule<Tree> KEY_GEN_65 =
+            new DetectionRuleBuilder<Tree>()
+                    .createDetectionRule()
+                    .forObjectTypes("ml_dsa::MlDsa65")
+                    .forMethods("key_gen")
+                    .shouldBeDetectedAs(new ValueActionFactory<>("ML-DSA-65"))
+                    .withMethodParameter("&mut impl CryptoRngCore")
+                    .buildForContext(new KeyContext(Map.of("kind", "ML-DSA")))
+                    .inBundle(() -> "RustCrypto")
+                    .withDependingDetectionRules(List.of(SIGN_65, VERIFY_65));
+
+    // ml_dsa::MlDsa87::key_gen(rng: &mut impl CryptoRngCore) -> (SigningKey, VerifyingKey)
+    // Generates an ML-DSA-87 key pair
+    private static final IDetectionRule<Tree> KEY_GEN_87 =
+            new DetectionRuleBuilder<Tree>()
+                    .createDetectionRule()
+                    .forObjectTypes("ml_dsa::MlDsa87")
+                    .forMethods("key_gen")
+                    .shouldBeDetectedAs(new ValueActionFactory<>("ML-DSA-87"))
+                    .withMethodParameter("&mut impl CryptoRngCore")
+                    .buildForContext(new KeyContext(Map.of("kind", "ML-DSA")))
+                    .inBundle(() -> "RustCrypto")
+                    .withDependingDetectionRules(List.of(SIGN_87, VERIFY_87));
+
+    @Nonnull
+    public static List<IDetectionRule<Tree>> rules() {
+        return List.of(KEY_GEN_44, KEY_GEN_65, KEY_GEN_87);
+    }
+}

--- a/rust/src/main/java/com/ibm/plugin/rules/detection/rustcrypto/RustCryptoMLKEM.java
+++ b/rust/src/main/java/com/ibm/plugin/rules/detection/rustcrypto/RustCryptoMLKEM.java
@@ -1,0 +1,177 @@
+/*
+ * Sonar Cryptography Plugin
+ * Copyright (C) 2024 PQCA
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ibm.plugin.rules.detection.rustcrypto;
+
+import com.ibm.engine.model.KeyAction;
+import com.ibm.engine.model.context.KeyContext;
+import com.ibm.engine.model.factory.KeyActionFactory;
+import com.ibm.engine.model.factory.ValueActionFactory;
+import com.ibm.engine.rule.IDetectionRule;
+import com.ibm.engine.rule.builder.DetectionRuleBuilder;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nonnull;
+import org.sonar.plugins.go.api.Tree;
+
+/**
+ * Detection rules for the RustCrypto ml-kem crate (NIST FIPS 203).
+ *
+ * <p>Detects usage of quantum-safe ML-KEM (Module-Lattice-Based Key Encapsulation Mechanism):
+ *
+ * <ul>
+ *   <li>ml_kem::MlKem512::generate - generates an ML-KEM-512 key pair
+ *   <li>ml_kem::MlKem768::generate - generates an ML-KEM-768 key pair
+ *   <li>ml_kem::MlKem1024::generate - generates an ML-KEM-1024 key pair
+ *   <li>DecapsulationKey::decapsulate - decapsulates a shared key
+ *   <li>EncapsulationKey::encapsulate - encapsulates a shared key
+ * </ul>
+ */
+@SuppressWarnings("java:S1192")
+public final class RustCryptoMLKEM {
+
+    private RustCryptoMLKEM() {
+        // private
+    }
+
+    // EncapsulationKey::encapsulate(&self, rng: &mut impl CryptoRngCore)
+    //     -> (Ciphertext, SharedKey)
+    // Encapsulates a shared key using the encapsulation key (ML-KEM-512)
+    private static final IDetectionRule<Tree> ENCAPSULATE_512 =
+            new DetectionRuleBuilder<Tree>()
+                    .createDetectionRule()
+                    .forObjectTypes("ml_kem::kem::EncapsulationKey<MlKem512Params>")
+                    .forMethods("encapsulate")
+                    .shouldBeDetectedAs(new KeyActionFactory<>(KeyAction.Action.ENCAPSULATION))
+                    .withMethodParameter("&mut impl CryptoRngCore")
+                    .buildForContext(new KeyContext(Map.of("kind", "KEM")))
+                    .inBundle(() -> "RustCrypto")
+                    .withoutDependingDetectionRules();
+
+    // EncapsulationKey::encapsulate for ML-KEM-768
+    private static final IDetectionRule<Tree> ENCAPSULATE_768 =
+            new DetectionRuleBuilder<Tree>()
+                    .createDetectionRule()
+                    .forObjectTypes("ml_kem::kem::EncapsulationKey<MlKem768Params>")
+                    .forMethods("encapsulate")
+                    .shouldBeDetectedAs(new KeyActionFactory<>(KeyAction.Action.ENCAPSULATION))
+                    .withMethodParameter("&mut impl CryptoRngCore")
+                    .buildForContext(new KeyContext(Map.of("kind", "KEM")))
+                    .inBundle(() -> "RustCrypto")
+                    .withoutDependingDetectionRules();
+
+    // EncapsulationKey::encapsulate for ML-KEM-1024
+    private static final IDetectionRule<Tree> ENCAPSULATE_1024 =
+            new DetectionRuleBuilder<Tree>()
+                    .createDetectionRule()
+                    .forObjectTypes("ml_kem::kem::EncapsulationKey<MlKem1024Params>")
+                    .forMethods("encapsulate")
+                    .shouldBeDetectedAs(new KeyActionFactory<>(KeyAction.Action.ENCAPSULATION))
+                    .withMethodParameter("&mut impl CryptoRngCore")
+                    .buildForContext(new KeyContext(Map.of("kind", "KEM")))
+                    .inBundle(() -> "RustCrypto")
+                    .withoutDependingDetectionRules();
+
+    // DecapsulationKey::decapsulate(&self, ciphertext: &Ciphertext) -> SharedKey
+    // Decapsulates a shared key from a ciphertext (ML-KEM-512)
+    private static final IDetectionRule<Tree> DECAPSULATE_512 =
+            new DetectionRuleBuilder<Tree>()
+                    .createDetectionRule()
+                    .forObjectTypes("ml_kem::kem::DecapsulationKey<MlKem512Params>")
+                    .forMethods("decapsulate")
+                    .shouldBeDetectedAs(new KeyActionFactory<>(KeyAction.Action.DECAPSULATION))
+                    .withMethodParameter("&Ciphertext")
+                    .buildForContext(new KeyContext(Map.of("kind", "KEM")))
+                    .inBundle(() -> "RustCrypto")
+                    .withoutDependingDetectionRules();
+
+    // DecapsulationKey::decapsulate for ML-KEM-768
+    private static final IDetectionRule<Tree> DECAPSULATE_768 =
+            new DetectionRuleBuilder<Tree>()
+                    .createDetectionRule()
+                    .forObjectTypes("ml_kem::kem::DecapsulationKey<MlKem768Params>")
+                    .forMethods("decapsulate")
+                    .shouldBeDetectedAs(new KeyActionFactory<>(KeyAction.Action.DECAPSULATION))
+                    .withMethodParameter("&Ciphertext")
+                    .buildForContext(new KeyContext(Map.of("kind", "KEM")))
+                    .inBundle(() -> "RustCrypto")
+                    .withoutDependingDetectionRules();
+
+    // DecapsulationKey::decapsulate for ML-KEM-1024
+    private static final IDetectionRule<Tree> DECAPSULATE_1024 =
+            new DetectionRuleBuilder<Tree>()
+                    .createDetectionRule()
+                    .forObjectTypes("ml_kem::kem::DecapsulationKey<MlKem1024Params>")
+                    .forMethods("decapsulate")
+                    .shouldBeDetectedAs(new KeyActionFactory<>(KeyAction.Action.DECAPSULATION))
+                    .withMethodParameter("&Ciphertext")
+                    .buildForContext(new KeyContext(Map.of("kind", "KEM")))
+                    .inBundle(() -> "RustCrypto")
+                    .withoutDependingDetectionRules();
+
+    // ml_kem::MlKem512::generate(rng: &mut impl CryptoRngCore)
+    //     -> (DecapsulationKey, EncapsulationKey)
+    // Generates an ML-KEM-512 key pair
+    private static final IDetectionRule<Tree> GENERATE_512 =
+            new DetectionRuleBuilder<Tree>()
+                    .createDetectionRule()
+                    .forObjectTypes("ml_kem::MlKem512")
+                    .forMethods("generate")
+                    .shouldBeDetectedAs(new ValueActionFactory<>("ML-KEM-512"))
+                    .withMethodParameter("&mut impl CryptoRngCore")
+                    .buildForContext(new KeyContext(Map.of("kind", "KEM")))
+                    .inBundle(() -> "RustCrypto")
+                    .withDependingDetectionRules(
+                            List.of(DECAPSULATE_512, ENCAPSULATE_512));
+
+    // ml_kem::MlKem768::generate(rng: &mut impl CryptoRngCore)
+    //     -> (DecapsulationKey, EncapsulationKey)
+    // Generates an ML-KEM-768 key pair
+    private static final IDetectionRule<Tree> GENERATE_768 =
+            new DetectionRuleBuilder<Tree>()
+                    .createDetectionRule()
+                    .forObjectTypes("ml_kem::MlKem768")
+                    .forMethods("generate")
+                    .shouldBeDetectedAs(new ValueActionFactory<>("ML-KEM-768"))
+                    .withMethodParameter("&mut impl CryptoRngCore")
+                    .buildForContext(new KeyContext(Map.of("kind", "KEM")))
+                    .inBundle(() -> "RustCrypto")
+                    .withDependingDetectionRules(
+                            List.of(DECAPSULATE_768, ENCAPSULATE_768));
+
+    // ml_kem::MlKem1024::generate(rng: &mut impl CryptoRngCore)
+    //     -> (DecapsulationKey, EncapsulationKey)
+    // Generates an ML-KEM-1024 key pair
+    private static final IDetectionRule<Tree> GENERATE_1024 =
+            new DetectionRuleBuilder<Tree>()
+                    .createDetectionRule()
+                    .forObjectTypes("ml_kem::MlKem1024")
+                    .forMethods("generate")
+                    .shouldBeDetectedAs(new ValueActionFactory<>("ML-KEM-1024"))
+                    .withMethodParameter("&mut impl CryptoRngCore")
+                    .buildForContext(new KeyContext(Map.of("kind", "KEM")))
+                    .inBundle(() -> "RustCrypto")
+                    .withDependingDetectionRules(
+                            List.of(DECAPSULATE_1024, ENCAPSULATE_1024));
+
+    @Nonnull
+    public static List<IDetectionRule<Tree>> rules() {
+        return List.of(GENERATE_512, GENERATE_768, GENERATE_1024);
+    }
+}

--- a/rust/src/main/java/com/ibm/plugin/rules/detection/rustcrypto/RustlsTLS.java
+++ b/rust/src/main/java/com/ibm/plugin/rules/detection/rustcrypto/RustlsTLS.java
@@ -1,0 +1,154 @@
+/*
+ * Sonar Cryptography Plugin
+ * Copyright (C) 2024 PQCA
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ibm.plugin.rules.detection.rustcrypto;
+
+import com.ibm.engine.model.context.ProtocolContext;
+import com.ibm.engine.model.factory.ValueActionFactory;
+import com.ibm.engine.rule.IDetectionRule;
+import com.ibm.engine.rule.builder.DetectionRuleBuilder;
+import java.util.List;
+import javax.annotation.Nonnull;
+import org.sonar.plugins.go.api.Tree;
+
+/**
+ * Detection rules for Rust's rustls TLS library.
+ *
+ * <p>Detects usage of:
+ *
+ * <ul>
+ *   <li>rustls::ClientConfig::builder - creates a TLS client configuration builder
+ *   <li>rustls::ServerConfig::builder - creates a TLS server configuration builder
+ *   <li>rustls::ClientConfig::builder_with_protocol_versions - creates a TLS client config with
+ *       specific protocol versions
+ *   <li>rustls::ServerConfig::builder_with_protocol_versions - creates a TLS server config with
+ *       specific protocol versions
+ *   <li>rustls::ClientConnection::new - creates a new TLS client connection
+ *   <li>rustls::ServerConnection::new - creates a new TLS server connection
+ * </ul>
+ */
+@SuppressWarnings("java:S1192")
+public final class RustlsTLS {
+
+    private RustlsTLS() {
+        // private
+    }
+
+    // rustls::ClientConfig::builder() -> ConfigBuilder<ClientConfig, WantsVerifier>
+    // Creates a TLS client configuration builder with default protocol versions
+    private static final IDetectionRule<Tree> CLIENT_CONFIG_BUILDER =
+            new DetectionRuleBuilder<Tree>()
+                    .createDetectionRule()
+                    .forObjectTypes("rustls::ClientConfig")
+                    .forMethods("builder")
+                    .shouldBeDetectedAs(new ValueActionFactory<>("TLS"))
+                    .withoutParameters()
+                    .buildForContext(new ProtocolContext(ProtocolContext.Kind.TLS))
+                    .inBundle(() -> "RustlsCrypto")
+                    .withoutDependingDetectionRules();
+
+    // rustls::ServerConfig::builder() -> ConfigBuilder<ServerConfig, WantsVerifier>
+    // Creates a TLS server configuration builder with default protocol versions
+    private static final IDetectionRule<Tree> SERVER_CONFIG_BUILDER =
+            new DetectionRuleBuilder<Tree>()
+                    .createDetectionRule()
+                    .forObjectTypes("rustls::ServerConfig")
+                    .forMethods("builder")
+                    .shouldBeDetectedAs(new ValueActionFactory<>("TLS"))
+                    .withoutParameters()
+                    .buildForContext(new ProtocolContext(ProtocolContext.Kind.TLS))
+                    .inBundle(() -> "RustlsCrypto")
+                    .withoutDependingDetectionRules();
+
+    // rustls::ClientConfig::builder_with_protocol_versions(
+    //     versions: &[&'static SupportedProtocolVersion]
+    // ) -> ConfigBuilder<ClientConfig, WantsVerifier>
+    // Creates a TLS client configuration builder with specific protocol versions
+    private static final IDetectionRule<Tree> CLIENT_CONFIG_BUILDER_WITH_VERSIONS =
+            new DetectionRuleBuilder<Tree>()
+                    .createDetectionRule()
+                    .forObjectTypes("rustls::ClientConfig")
+                    .forMethods("builder_with_protocol_versions")
+                    .shouldBeDetectedAs(new ValueActionFactory<>("TLS"))
+                    .withMethodParameter("&[&SupportedProtocolVersion]")
+                    .buildForContext(new ProtocolContext(ProtocolContext.Kind.TLS))
+                    .inBundle(() -> "RustlsCrypto")
+                    .withoutDependingDetectionRules();
+
+    // rustls::ServerConfig::builder_with_protocol_versions(
+    //     versions: &[&'static SupportedProtocolVersion]
+    // ) -> ConfigBuilder<ServerConfig, WantsVerifier>
+    // Creates a TLS server configuration builder with specific protocol versions
+    private static final IDetectionRule<Tree> SERVER_CONFIG_BUILDER_WITH_VERSIONS =
+            new DetectionRuleBuilder<Tree>()
+                    .createDetectionRule()
+                    .forObjectTypes("rustls::ServerConfig")
+                    .forMethods("builder_with_protocol_versions")
+                    .shouldBeDetectedAs(new ValueActionFactory<>("TLS"))
+                    .withMethodParameter("&[&SupportedProtocolVersion]")
+                    .buildForContext(new ProtocolContext(ProtocolContext.Kind.TLS))
+                    .inBundle(() -> "RustlsCrypto")
+                    .withoutDependingDetectionRules();
+
+    // rustls::ClientConnection::new(
+    //     config: Arc<ClientConfig>, name: ServerName<'_>
+    // ) -> Result<Self, Error>
+    // Creates a new TLS client connection with the given configuration
+    private static final IDetectionRule<Tree> CLIENT_CONNECTION_NEW =
+            new DetectionRuleBuilder<Tree>()
+                    .createDetectionRule()
+                    .forObjectTypes("rustls::ClientConnection")
+                    .forMethods("new")
+                    .shouldBeDetectedAs(new ValueActionFactory<>("TLS"))
+                    .withMethodParameter("Arc<ClientConfig>")
+                    .addDependingDetectionRules(
+                            List.of(CLIENT_CONFIG_BUILDER, CLIENT_CONFIG_BUILDER_WITH_VERSIONS))
+                    .withMethodParameter("ServerName")
+                    .buildForContext(new ProtocolContext(ProtocolContext.Kind.TLS))
+                    .inBundle(() -> "RustlsCrypto")
+                    .withoutDependingDetectionRules();
+
+    // rustls::ServerConnection::new(
+    //     config: Arc<ServerConfig>
+    // ) -> Result<Self, Error>
+    // Creates a new TLS server connection with the given configuration
+    private static final IDetectionRule<Tree> SERVER_CONNECTION_NEW =
+            new DetectionRuleBuilder<Tree>()
+                    .createDetectionRule()
+                    .forObjectTypes("rustls::ServerConnection")
+                    .forMethods("new")
+                    .shouldBeDetectedAs(new ValueActionFactory<>("TLS"))
+                    .withMethodParameter("Arc<ServerConfig>")
+                    .addDependingDetectionRules(
+                            List.of(SERVER_CONFIG_BUILDER, SERVER_CONFIG_BUILDER_WITH_VERSIONS))
+                    .buildForContext(new ProtocolContext(ProtocolContext.Kind.TLS))
+                    .inBundle(() -> "RustlsCrypto")
+                    .withoutDependingDetectionRules();
+
+    @Nonnull
+    public static List<IDetectionRule<Tree>> rules() {
+        return List.of(
+                CLIENT_CONFIG_BUILDER,
+                SERVER_CONFIG_BUILDER,
+                CLIENT_CONFIG_BUILDER_WITH_VERSIONS,
+                SERVER_CONFIG_BUILDER_WITH_VERSIONS,
+                CLIENT_CONNECTION_NEW,
+                SERVER_CONNECTION_NEW);
+    }
+}

--- a/rust/src/main/resources/org/sonar/l10n/rust/rules/rust/Inventory.html
+++ b/rust/src/main/resources/org/sonar/l10n/rust/rules/rust/Inventory.html
@@ -1,0 +1,9 @@
+<h2>Cryptography Usage: Be careful</h2>
+
+<p>Cryptography is a critical component of modern digital security, protecting sensitive data and communications
+    from unauthorized access. However, implementing cryptographic systems correctly is notoriously challenging,
+    even for experienced developers. Therefore, caution is necessary when writing code related to
+    cryptography.</p>
+
+<p>It is important that you read the documentation for the cryptographic library you are using and strictly
+    adhere to the specified implementation guidelines.</p>

--- a/rust/src/main/resources/org/sonar/l10n/rust/rules/rust/Inventory.json
+++ b/rust/src/main/resources/org/sonar/l10n/rust/rules/rust/Inventory.json
@@ -1,0 +1,17 @@
+{
+  "title": "Cryptographic Inventory (CBOM)",
+  "type": "CODE_SMELL",
+  "status": "ready",
+  "remediation": {
+    "func": "Constant\/Issue",
+    "constantCost": "5min"
+  },
+  "tags": [
+    "cryptography",
+    "cbom",
+    "cwe"
+  ],
+  "defaultSeverity": "Minor",
+  "scope": "Main",
+  "sqKey": "Inventory"
+}

--- a/rust/src/test/java/com/ibm/plugin/rules/detection/RustDetectionRulesTest.java
+++ b/rust/src/test/java/com/ibm/plugin/rules/detection/RustDetectionRulesTest.java
@@ -1,0 +1,52 @@
+/*
+ * Sonar Cryptography Plugin
+ * Copyright (C) 2024 PQCA
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ibm.plugin.rules.detection;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.ibm.engine.rule.IDetectionRule;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.sonar.plugins.go.api.Tree;
+
+class RustDetectionRulesTest {
+
+    @Test
+    void shouldReturnNonEmptyRules() {
+        List<IDetectionRule<Tree>> rules = RustDetectionRules.rules();
+        assertThat(rules).isNotNull().isNotEmpty();
+    }
+
+    @Test
+    void shouldContainAllExpectedRuleCounts() {
+        List<IDetectionRule<Tree>> rules = RustDetectionRules.rules();
+        // ring: 4 RSA + 4 ECDSA + 2 ECDH = 10
+        // rustls: 6 TLS
+        // RustCrypto: 3 ML-KEM + 3 ML-DSA = 6
+        // Total: 22
+        assertThat(rules).hasSize(22);
+    }
+
+    @Test
+    void shouldReturnUnmodifiableRules() {
+        List<IDetectionRule<Tree>> rules = RustDetectionRules.rules();
+        assertThat(rules).isUnmodifiable();
+    }
+}

--- a/rust/src/test/java/com/ibm/plugin/rules/detection/rustcrypto/RingECDHTest.java
+++ b/rust/src/test/java/com/ibm/plugin/rules/detection/rustcrypto/RingECDHTest.java
@@ -1,0 +1,52 @@
+/*
+ * Sonar Cryptography Plugin
+ * Copyright (C) 2024 PQCA
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ibm.plugin.rules.detection.rustcrypto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.ibm.engine.rule.IDetectionRule;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.sonar.plugins.go.api.Tree;
+
+class RingECDHTest {
+
+    @Test
+    void shouldReturnTwoRules() {
+        List<IDetectionRule<Tree>> rules = RingECDH.rules();
+        assertThat(rules).hasSize(2);
+    }
+
+    @Test
+    void shouldReturnNonNullRules() {
+        List<IDetectionRule<Tree>> rules = RingECDH.rules();
+        assertThat(rules).isNotNull().allSatisfy(rule -> assertThat(rule).isNotNull());
+    }
+
+    @Test
+    void shouldHaveCorrectBundleIdentifier() {
+        List<IDetectionRule<Tree>> rules = RingECDH.rules();
+        assertThat(rules)
+                .allSatisfy(
+                        rule ->
+                                assertThat(rule.bundle().getIdentifier())
+                                        .isEqualTo("RingCrypto"));
+    }
+}

--- a/rust/src/test/java/com/ibm/plugin/rules/detection/rustcrypto/RingECDSATest.java
+++ b/rust/src/test/java/com/ibm/plugin/rules/detection/rustcrypto/RingECDSATest.java
@@ -1,0 +1,52 @@
+/*
+ * Sonar Cryptography Plugin
+ * Copyright (C) 2024 PQCA
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ibm.plugin.rules.detection.rustcrypto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.ibm.engine.rule.IDetectionRule;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.sonar.plugins.go.api.Tree;
+
+class RingECDSATest {
+
+    @Test
+    void shouldReturnFourRules() {
+        List<IDetectionRule<Tree>> rules = RingECDSA.rules();
+        assertThat(rules).hasSize(4);
+    }
+
+    @Test
+    void shouldReturnNonNullRules() {
+        List<IDetectionRule<Tree>> rules = RingECDSA.rules();
+        assertThat(rules).isNotNull().allSatisfy(rule -> assertThat(rule).isNotNull());
+    }
+
+    @Test
+    void shouldHaveCorrectBundleIdentifier() {
+        List<IDetectionRule<Tree>> rules = RingECDSA.rules();
+        assertThat(rules)
+                .allSatisfy(
+                        rule ->
+                                assertThat(rule.bundle().getIdentifier())
+                                        .isEqualTo("RingCrypto"));
+    }
+}

--- a/rust/src/test/java/com/ibm/plugin/rules/detection/rustcrypto/RingRSATest.java
+++ b/rust/src/test/java/com/ibm/plugin/rules/detection/rustcrypto/RingRSATest.java
@@ -1,0 +1,49 @@
+/*
+ * Sonar Cryptography Plugin
+ * Copyright (C) 2024 PQCA
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ibm.plugin.rules.detection.rustcrypto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.ibm.engine.rule.IDetectionRule;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.sonar.plugins.go.api.Tree;
+
+class RingRSATest {
+
+    @Test
+    void shouldReturnFourRules() {
+        List<IDetectionRule<Tree>> rules = RingRSA.rules();
+        assertThat(rules).hasSize(4);
+    }
+
+    @Test
+    void shouldReturnNonNullRules() {
+        List<IDetectionRule<Tree>> rules = RingRSA.rules();
+        assertThat(rules).isNotNull().allSatisfy(rule -> assertThat(rule).isNotNull());
+    }
+
+    @Test
+    void shouldHaveCorrectBundleIdentifier() {
+        List<IDetectionRule<Tree>> rules = RingRSA.rules();
+        assertThat(rules)
+                .allSatisfy(rule -> assertThat(rule.bundle().getIdentifier()).isEqualTo("RingCrypto"));
+    }
+}

--- a/rust/src/test/java/com/ibm/plugin/rules/detection/rustcrypto/RustCryptoMLDSATest.java
+++ b/rust/src/test/java/com/ibm/plugin/rules/detection/rustcrypto/RustCryptoMLDSATest.java
@@ -1,0 +1,64 @@
+/*
+ * Sonar Cryptography Plugin
+ * Copyright (C) 2024 PQCA
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ibm.plugin.rules.detection.rustcrypto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.ibm.engine.rule.IDetectionRule;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.sonar.plugins.go.api.Tree;
+
+class RustCryptoMLDSATest {
+
+    @Test
+    void shouldReturnThreeRules() {
+        List<IDetectionRule<Tree>> rules = RustCryptoMLDSA.rules();
+        assertThat(rules).hasSize(3);
+    }
+
+    @Test
+    void shouldReturnNonNullRules() {
+        List<IDetectionRule<Tree>> rules = RustCryptoMLDSA.rules();
+        assertThat(rules).isNotNull().allSatisfy(rule -> assertThat(rule).isNotNull());
+    }
+
+    @Test
+    void shouldHaveCorrectBundleIdentifier() {
+        List<IDetectionRule<Tree>> rules = RustCryptoMLDSA.rules();
+        assertThat(rules)
+                .allSatisfy(
+                        rule ->
+                                assertThat(rule.bundle().getIdentifier())
+                                        .isEqualTo("RustCrypto"));
+    }
+
+    @Test
+    void shouldHaveDependingDetectionRules() {
+        List<IDetectionRule<Tree>> rules = RustCryptoMLDSA.rules();
+        // Each key_gen rule should have depending detection rules (sign + verify)
+        assertThat(rules)
+                .allSatisfy(
+                        rule ->
+                                assertThat(rule.nextDetectionRules())
+                                        .isNotNull()
+                                        .isNotEmpty());
+    }
+}

--- a/rust/src/test/java/com/ibm/plugin/rules/detection/rustcrypto/RustCryptoMLKEMTest.java
+++ b/rust/src/test/java/com/ibm/plugin/rules/detection/rustcrypto/RustCryptoMLKEMTest.java
@@ -1,0 +1,64 @@
+/*
+ * Sonar Cryptography Plugin
+ * Copyright (C) 2024 PQCA
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ibm.plugin.rules.detection.rustcrypto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.ibm.engine.rule.IDetectionRule;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.sonar.plugins.go.api.Tree;
+
+class RustCryptoMLKEMTest {
+
+    @Test
+    void shouldReturnThreeRules() {
+        List<IDetectionRule<Tree>> rules = RustCryptoMLKEM.rules();
+        assertThat(rules).hasSize(3);
+    }
+
+    @Test
+    void shouldReturnNonNullRules() {
+        List<IDetectionRule<Tree>> rules = RustCryptoMLKEM.rules();
+        assertThat(rules).isNotNull().allSatisfy(rule -> assertThat(rule).isNotNull());
+    }
+
+    @Test
+    void shouldHaveCorrectBundleIdentifier() {
+        List<IDetectionRule<Tree>> rules = RustCryptoMLKEM.rules();
+        assertThat(rules)
+                .allSatisfy(
+                        rule ->
+                                assertThat(rule.bundle().getIdentifier())
+                                        .isEqualTo("RustCrypto"));
+    }
+
+    @Test
+    void shouldHaveDependingDetectionRules() {
+        List<IDetectionRule<Tree>> rules = RustCryptoMLKEM.rules();
+        // Each generate rule should have depending detection rules (encapsulate + decapsulate)
+        assertThat(rules)
+                .allSatisfy(
+                        rule ->
+                                assertThat(rule.nextDetectionRules())
+                                        .isNotNull()
+                                        .isNotEmpty());
+    }
+}

--- a/rust/src/test/java/com/ibm/plugin/rules/detection/rustcrypto/RustlsTLSTest.java
+++ b/rust/src/test/java/com/ibm/plugin/rules/detection/rustcrypto/RustlsTLSTest.java
@@ -1,0 +1,52 @@
+/*
+ * Sonar Cryptography Plugin
+ * Copyright (C) 2024 PQCA
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ibm.plugin.rules.detection.rustcrypto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.ibm.engine.rule.IDetectionRule;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.sonar.plugins.go.api.Tree;
+
+class RustlsTLSTest {
+
+    @Test
+    void shouldReturnSixRules() {
+        List<IDetectionRule<Tree>> rules = RustlsTLS.rules();
+        assertThat(rules).hasSize(6);
+    }
+
+    @Test
+    void shouldReturnNonNullRules() {
+        List<IDetectionRule<Tree>> rules = RustlsTLS.rules();
+        assertThat(rules).isNotNull().allSatisfy(rule -> assertThat(rule).isNotNull());
+    }
+
+    @Test
+    void shouldHaveCorrectBundleIdentifier() {
+        List<IDetectionRule<Tree>> rules = RustlsTLS.rules();
+        assertThat(rules)
+                .allSatisfy(
+                        rule ->
+                                assertThat(rule.bundle().getIdentifier())
+                                        .isEqualTo("RustlsCrypto"));
+    }
+}


### PR DESCRIPTION
Add Rust cryptographic detection rules. It's the first Rust language support in sonar-cryptography.

Relates to #472

**22 detection rules across 6 classes:**

| Library | Class | Rules | Detects |
|---------|-------|-------|---------|
| ring | `RingRSA` | 4 | from_pkcs8, from_der, sign, verify |
| ring | `RingECDSA` | 4 | from_pkcs8, from_private_key, sign, verify |
| ring | `RingECDH` | 2 | generate, agree_ephemeral |
| rustls | `RustlsTLS` | 6 | ClientConfig/ServerConfig builders, connections |
| RustCrypto | `RustCryptoMLKEM` | 3 | ML-KEM-512/768/1024 generate + encapsulate/decapsulate |
| RustCrypto | `RustCryptoMLDSA` | 3 | ML-DSA-44/65/87 key_gen + sign/verify |

Follows the Go module pattern exactly: `RustDetectionRules.java` aggregator, per-library rule classes with `DetectionRuleBuilder`, SonarQube metadata, 7 test files. Module added to parent `pom.xml`.