### PR TITLE
docs: fix stale rule info in README, document CBOM filename setting, add Go to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,7 @@ This is the **Sonar Cryptography Plugin (CBOMkit-hyperion)** - a SonarQube plugi
 **Supported languages/libraries:**
 - Java: JCA (100%), BouncyCastle light-weight API (100%)
 - Python: pyca/cryptography (100%)
+- Go: `crypto` standard library (100%, except `crypto/x509`), `golang.org/x/crypto` (partial: `hkdf`, `pbkdf2`, `sha3`)
 
 ## Build Commands
 
@@ -40,6 +41,8 @@ mvn test
 
 # Run tests for specific module
 mvn test -pl java
+mvn test -pl python
+mvn test -pl go
 mvn test -pl mapper
 mvn test -pl engine
 
@@ -53,8 +56,8 @@ mvn test -Dtest=SimpleGuidelineTest#testBasicAssertion
 **Testing Framework:** JUnit 5 + AssertJ + SonarQube Test Fixtures
 
 **Detection rule tests:**
-- Extend `TestBase` (in `java/src/test/java/com/ibm/plugin/TestBase.java`)
-- Use `CheckVerifier` from SonarQube
+- Extend the `TestBase` of the language module you're testing (`java`, `python` and `go` each have their own at `<module>/src/test/java/com/ibm/plugin/TestBase.java`)
+- Use the SonarQube verifier for that language: `CheckVerifier` (Java), `PythonCheckVerifier` (Python), `GoVerifier` (Go)
 - Test files (actual code to analyze) go in `src/test/files/`, not `src/test/java/`
 - Implement `asserts()` method to verify detection store values and translated nodes
 
@@ -72,6 +75,8 @@ engine/                       # Core detection engine
 java/                         # Java language support (JCA, BouncyCastle)
 ├── rules/detection/          # Java detection rules
 python/                       # Python language support (pyca/cryptography)
+go/                           # Go language support (crypto stdlib, golang.org/x/crypto)
+├── rules/detection/gocrypto/ # Go detection rules
 mapper/                       # Translation layer to CBOM model
 ├── model/                    # Core data model (Algorithm, Key, Protocol, etc.)
 ├── ITranslator.java          # Main translation interface
@@ -102,3 +107,5 @@ Plugin JAR is built to `sonar-cryptography-plugin/target/` and copied to `.Sonar
 - `docs/LANGUAGE_SUPPORT.md` - Extending for new languages/libraries
 - `docs/DETECTION_RULE_STRUCTURE.md` - Writing detection rules
 - `docs/TROUBLESHOOTING.md` - Testing configuration guide
+- `docs/PERFORMANCE_TESTING.md` - Runtime/heap measurement, including full Keycloak scans
+- `README.md` (Build section) - Adding packages to `sonar-go-to-slang` when Go type resolution fails

--- a/README.md
+++ b/README.md
@@ -63,28 +63,49 @@ SonarQube ([more](https://docs.sonarqube.org/latest/setup-and-upgrade/install-a-
 
 ## Using
 
-The plugin provides new inventory rules (Cbomkit Cryptography Repository) regarding the use of cryptography for 
-the supported languages.
-If you enable these rules, a source code scan creates a cryptographic inventory by creating a 
-[CBOM](https://cyclonedx.org/capabilities/cbom/) with all cryptographic assets and writing 
-a `cbom.json` to the scan directory.
+The plugin provides new rules regarding the use of cryptography for the supported languages.
+They are grouped in the **Sonar Cryptography** rule repositories, one per language
+(`sonar-java-crypto`, `sonar-python-crypto` and `sonar-go-crypto`).
+If you enable the *Cryptographic Inventory (CBOM)* rule, a source code scan creates a cryptographic
+inventory by creating a [CBOM](https://cyclonedx.org/capabilities/cbom/) with all cryptographic
+assets and writing a `cbom.json` to the scan directory.
 
 ### Add Cryptography Rules to your Quality Profile
 
 This plugin incorporates rules specifically focused on cryptography.
 
-> To generate a Cryptography Bill of Materials (CBOM), it is mandatory to activate at 
-> least one of these cryptography-related rules.
+> To generate a Cryptography Bill of Materials (CBOM), it is mandatory to activate the
+> *Cryptographic Inventory (CBOM)* rule.
 
 ![Activate Rules Crypto Rules](docs/images/rules.png)
 
-As of the current version, the plugin contains one single rule for creating a cryptographic inventory. 
-Future updates may introduce additional rules to expand functionality.
+The plugin currently ships these rules:
+
+| Rule                                                     | Languages        | Contributes to the CBOM |
+|----------------------------------------------------------|------------------|-------------------------|
+| *Cryptographic Inventory (CBOM)*                         | Java, Python, Go | yes                     |
+| *Do not use MD5 for cryptographic purposes like hashing* | Java, Python     | no                      |
+
+Only the *Cryptographic Inventory (CBOM)* rule writes a `cbom.json`; the other rules just raise
+issues on the scanned code. Future updates may introduce additional rules to expand functionality.
 
 ### Scan Source Code
 
 Now you can follow the [SonarQube documentation](https://docs.sonarqube.org/latest/analyzing-source-code/overview/) 
 to start your first scan.
+
+### Configuration
+
+| Property                   | Default | Scope   | Description                                                                   |
+|----------------------------|---------|---------|-------------------------------------------------------------------------------|
+| `sonar.cryptoScanner.cbom` | `cbom`  | Project | Filename (without extension) of the generated CBOM, written as `<name>.json`. |
+
+The property can be set in the SonarQube UI under *Project Settings → General*, or passed to the
+scanner directly:
+
+```bash
+sonar-scanner -Dsonar.cryptoScanner.cbom=my-cbom
+```
 
 ### Visualizing your CBOM
 


### PR DESCRIPTION
Documentation drift in `README.md` and `CLAUDE.md`.

## README — "Using" section

**1. Rule repository name.** The README told users to look for a "Cbomkit Cryptography Repository". That string appears nowhere in the codebase — the plugin registers repositories named **Sonar Cryptography** with keys `sonar-java-crypto`, `sonar-python-crypto` and `sonar-go-crypto` (`JavaScannerRuleDefinition.java:31-32` and the Python/Go equivalents).

**2. "one single rule".** There are now two rules. Replaced the claim with a table:

| Rule | Languages | Contributes to the CBOM |
|------|-----------|-------------------------|
| *Cryptographic Inventory (CBOM)* | Java, Python, Go | yes |
| *Do not use MD5 for cryptographic purposes like hashing* | Java, Python | no |

**3. CBOM generation precondition.** The old text said it is "mandatory to activate at least one of these cryptography-related rules". That is wrong: `JavaBaseDetectionRule.update` only calls `JavaAggregator.addNodes` when `isInventory` is true, which only `JavaInventoryRule` sets. Activating just the MD5 rule raises issues but produces no `cbom.json`. The instruction now names the *Cryptographic Inventory (CBOM)* rule specifically.

**4. Undocumented setting.** Added a Configuration subsection for `sonar.cryptoScanner.cbom` (registered in `Configuration.java`, project scope, default `cbom`, `.json` appended in `OutputFileJob.java:47`). It appeared in no markdown file before.

## CLAUDE.md — Go module

Go support was missing entirely: added it to the supported-languages list (`crypto` stdlib except `crypto/x509`, plus the partial `golang.org/x/crypto` coverage), to the module tree, and to the per-module test commands (`-pl go`, and `-pl python` which was also absent). Detection-rule test guidance pointed only at the Java `TestBase`/`CheckVerifier`; each language module has its own `TestBase` and verifier (`CheckVerifier` / `PythonCheckVerifier` / `GoVerifier`). Also listed `docs/PERFORMANCE_TESTING.md` and the README's `sonar-go-to-slang` instructions under key documentation.

## Not addressed

`docs/images/rules.png` is stale — it shows two repositories and "1 rules", so it now visibly disagrees with the rule table above it. It needs a fresh capture from a SonarQube instance running the 2.x plugin, which I could not produce here.