### PR TITLE
Feat: withNamedMethodParameter() for python detection rules and tests

### DIFF
--- a/engine/src/main/java/com/ibm/engine/language/python/PythonDetectionEngine.java
+++ b/engine/src/main/java/com/ibm/engine/language/python/PythonDetectionEngine.java
@@ -32,14 +32,20 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.sonar.plugins.python.api.PythonCheck;
 import org.sonar.plugins.python.api.PythonVisitorContext;
 import org.sonar.plugins.python.api.symbols.Symbol;
 import org.sonar.plugins.python.api.tree.*;
 
 public class PythonDetectionEngine implements IDetectionEngine<Tree, Symbol> {
+    private static final Logger LOG = LoggerFactory.getLogger(PythonDetectionEngine.class);
+
     @Nonnull
     private final DetectionStore<PythonCheck, Tree, Symbol, PythonVisitorContext> detectionStore;
 
@@ -351,6 +357,29 @@ public class PythonDetectionEngine implements IDetectionEngine<Tree, Symbol> {
     @Nonnull
     private Optional<TraceSymbol<Symbol>> getTraceSymbol(
             @Nonnull Parameter<Tree> parameter, @Nonnull List<Argument> arguments) {
+        Optional<String> keywordName = parameter.getKeywordName();
+        if (keywordName.isPresent()) {
+            // Named parameter: keyword-name lookup first, then positional fallback
+            Optional<Argument> resolved =
+                    findArgumentByKeyword(keywordName.get(), parameter.getIndex(), arguments);
+            if (resolved.isEmpty()) {
+                if (parameter.isKeywordOptional()) {
+                    return Optional.of(TraceSymbol.createWithStateDifferent());
+                }
+                return Optional.of(TraceSymbol.createWithStateDifferent());
+            }
+            Argument arg = resolved.get();
+            if (arg instanceof RegularArgument regularArg) {
+                Expression expressionArg = regularArg.expression();
+                if (expressionArg.is(Tree.Kind.NAME)) {
+                    Name nameArg = (Name) expressionArg;
+                    return Optional.of(TraceSymbol.createFrom(nameArg.symbol()));
+                }
+            }
+            return Optional.of(TraceSymbol.createWithStateNoSymbol());
+        }
+
+        // Positional parameter (original behaviour)
         if (parameter.getIndex() >= arguments.size()) {
             return Optional.of(TraceSymbol.createWithStateDifferent());
         }
@@ -414,10 +443,6 @@ public class PythonDetectionEngine implements IDetectionEngine<Tree, Symbol> {
         }
 
         DetectionRule<Tree> detectionRule = (DetectionRule<Tree>) detectionStore.getDetectionRule();
-        if (detectionRule.actionFactory() != null) {
-            MethodDetection<Tree> methodDetection = new MethodDetection<>(expressionTree, null);
-            detectionStore.onReceivingNewDetection(methodDetection);
-        }
 
         // Extracts the arguments for the provided expression
         List<Argument> arguments = expressionTree.arguments();
@@ -427,57 +452,211 @@ public class PythonDetectionEngine implements IDetectionEngine<Tree, Symbol> {
         // TODO: It would be better to have a case disjunction to use either
         // isInvocationOnVariable or isInitForVariable, but it is difficult in Python
 
-        int index = 0;
+        // When named parameters are present, reject any call site that passes a keyword argument
+        // whose name is not declared in the rule. Such a call cannot match the function signature
+        // the rule was written for, so it must not fire. This check must happen before emitting
+        // MethodDetection so that rejected calls produce no finding at all.
+        // Positional-only rules are unaffected: the MethodMatcher's exact-count check already
+        // rejects wrong-signature calls before we reach this point.
+        boolean hasNamedParams =
+                detectionRule.parameters().stream().anyMatch(p -> p.getKeywordName().isPresent());
+        if (hasNamedParams) {
+            // Reject if any argument is a dict-unpacking expression (**d) or a sequence-unpacking
+            // expression (*args). We cannot statically inspect what keys or values they contain,
+            // so we cannot verify the call matches the rule's declared parameters.
+            boolean hasUnpackingArg =
+                    arguments.stream().anyMatch(a -> !(a instanceof RegularArgument));
+            if (hasUnpackingArg) {
+                return;
+            }
+
+            // Reject if any keyword argument name is not declared in the rule.
+            Set<String> declaredKeywordNames =
+                    detectionRule.parameters().stream()
+                            .flatMap(p -> p.getKeywordName().stream())
+                            .collect(Collectors.toSet());
+            boolean hasUnknownKeyword =
+                    arguments.stream()
+                            .anyMatch(
+                                    a ->
+                                            a instanceof RegularArgument ra
+                                                    && ra.keywordArgument() != null
+                                                    && !declaredKeywordNames.contains(
+                                                            ra.keywordArgument().name()));
+            if (hasUnknownKeyword) {
+                return;
+            }
+        }
+
+        if (detectionRule.actionFactory() != null) {
+            MethodDetection<Tree> methodDetection = new MethodDetection<>(expressionTree, null);
+            detectionStore.onReceivingNewDetection(methodDetection);
+        }
+
+        // Track whether a preceding optional named parameter was skipped (Hole 1 mitigation).
+        boolean precedingOptionalNamedParamWasSkipped = false;
+
+        int positionalIndex = 0; // tracks the index among all parameters (for positional fallback)
         for (Parameter<Tree> parameter : detectionRule.parameters()) {
-            if (!checkCurrentIndexState(
-                    index, arguments, isInvocation, traceSymbol, expressionTree)) {
-                index++;
-                continue;
-            }
-            // the expression tree of the parameter
-            Tree expression = arguments.get(index); // this is an Argument tree
-            if (expression instanceof RegularArgument regularArgument) {
-                expression = regularArgument.expression();
-            }
+            Optional<String> keywordName = parameter.getKeywordName();
 
-            /*
-             * This method resolves the detection parameter in an inner scope.
-             * If unsuccessful, it falls back to resolving values in the outer scope using the provided expression and detectableParameter.
-             */
-            if (parameter.is(DetectableParameter.class)) {
-                DetectableParameter<Tree> detectableParameter =
-                        (DetectableParameter<Tree>) parameter;
-                // try to resolve value in inner scope
-                List<ResolvedValue<Object, Tree>> resolvedValues =
-                        resolveValuesInInnerScope(
-                                Object.class, expression, detectableParameter.getiValueFactory());
-                if (resolvedValues.isEmpty()) {
-                    // goto outer scope
-                    resolveValuesInOuterScope(expression, detectableParameter);
-                } else {
-                    resolvedValues.stream()
-                            .map(
-                                    resolvedValue ->
-                                            new ValueDetection<>(
-                                                    resolvedValue,
-                                                    detectableParameter,
-                                                    expressionTree,
-                                                    expressionTree))
-                            .forEach(detectionStore::onReceivingNewDetection);
+            if (keywordName.isPresent()) {
+                // --- Named parameter extraction (proposal §3) ---
+                Optional<Argument> resolvedArg =
+                        findArgumentByKeyword(keywordName.get(), positionalIndex, arguments);
+
+                if (resolvedArg.isEmpty()) {
+                    if (parameter.isKeywordOptional()) {
+                        // optional parameter absent → skip silently
+                        precedingOptionalNamedParamWasSkipped = true;
+                        positionalIndex++;
+                        continue;
+                    } else {
+                        // required named parameter absent → rule does not fire; stop processing
+                        return;
+                    }
                 }
-            } else if (!parameter.getDetectionRules().isEmpty()) {
-                /*
-                 * This case is reached when the parameter is not a DetectableParameter (the rule does not contains `.shouldBeDetectedAs`),
-                 * but has depending detection rules (the rule contain `.addDependingDetectionRules`).
-                 * This happens usually for parameters that are intermediary function, that we have to resolve but we don't want to capture their value.
-                 * In this case, we resolve the parameter with the depending detection rule with an EXPRESSION scope,
-                 * this way we ensure to only resolve the right parameter content and not similar calls in the same function scope.
-                 */
-                detectionStore.onDetectedDependingParameter(
-                        parameter, expression, DetectionStore.Scope.EXPRESSION);
+
+                // Check whether we used positional fallback AND a preceding optional was skipped
+                // (Hole 1 warning — proposal §5).
+                Argument arg = resolvedArg.get();
+                boolean usedPositionalFallback =
+                        (arg instanceof RegularArgument ra && ra.keywordArgument() == null);
+                if (usedPositionalFallback && precedingOptionalNamedParamWasSkipped) {
+                    LOG.warn(
+                            "Named parameter \"{}\" resolved via positional fallback at index {},"
+                                    + " but a preceding optional named parameter was not found."
+                                    + " The positional argument may belong to a different parameter."
+                                    + " Rule: {}, location: {}",
+                            keywordName.get(),
+                            positionalIndex,
+                            detectionStore.getDetectionRule().getClass().getSimpleName(),
+                            expressionTree.firstToken().value());
+                }
+
+                // extract expression from the resolved argument
+                Tree expression = arg;
+                if (expression instanceof RegularArgument regularArgument) {
+                    expression = regularArgument.expression();
+                }
+
+                // Type check: verify the resolved argument's type against the declared parameter
+                // type. Skipped when the declared type is ANY (wildcard). When the type cannot be
+                // statically resolved, resolveTreeType returns an accept-all IType — the same
+                // conservative behaviour used by MethodMatcher for positional parameters.
+                if (!parameter.getParameterType().equals(MethodMatcher.ANY)) {
+                    Optional<IType> resolvedType = PythonSemantic.resolveTreeType(expression);
+                    boolean typeMatches =
+                            resolvedType.map(t -> t.is(parameter.getParameterType())).orElse(true);
+                    if (!typeMatches) {
+                        if (parameter.isKeywordOptional()) {
+                            // Type mismatch on an optional param: treat as absent and skip.
+                            precedingOptionalNamedParamWasSkipped = true;
+                            positionalIndex++;
+                            continue;
+                        } else {
+                            // Type mismatch on a required param: rule does not fire.
+                            return;
+                        }
+                    }
+                }
+
+                if (!checkCurrentIndexState(
+                        positionalIndex, arguments, isInvocation, traceSymbol, expressionTree)) {
+                    positionalIndex++;
+                    continue;
+                }
+
+                processParameterExpression(parameter, expression, expressionTree);
+            } else {
+                // --- Positional parameter extraction (original behaviour) ---
+                if (!checkCurrentIndexState(
+                        positionalIndex, arguments, isInvocation, traceSymbol, expressionTree)) {
+                    positionalIndex++;
+                    continue;
+                }
+                Tree expression = arguments.get(positionalIndex);
+                if (expression instanceof RegularArgument regularArgument) {
+                    expression = regularArgument.expression();
+                }
+
+                processParameterExpression(parameter, expression, expressionTree);
             }
 
-            index++;
+            positionalIndex++;
+        }
+    }
+
+    /**
+     * Tries to find an argument matching the given keyword name. Falls back to the positional index
+     * if no keyword-named argument is found and the argument at that index is positional (i.e. has
+     * no keyword name itself).
+     *
+     * @param keywordName the name to look for as a keyword argument
+     * @param positionalIndex the fallback positional index
+     * @param arguments the full argument list at the call site
+     * @return the matching argument, or empty if neither keyword nor positional match is available
+     */
+    @Nonnull
+    private Optional<Argument> findArgumentByKeyword(
+            @Nonnull String keywordName, int positionalIndex, @Nonnull List<Argument> arguments) {
+        // Step 1: keyword-name lookup
+        for (Argument arg : arguments) {
+            if (arg instanceof RegularArgument ra
+                    && ra.keywordArgument() != null
+                    && keywordName.equals(ra.keywordArgument().name())) {
+                return Optional.of(arg);
+            }
+        }
+        // Step 2: positional fallback — accept only if the argument at positionalIndex is itself
+        // positional (no keyword marker) to avoid misattributing a keyword arg to the wrong param.
+        if (positionalIndex < arguments.size()) {
+            Argument arg = arguments.get(positionalIndex);
+            if (arg instanceof RegularArgument ra && ra.keywordArgument() == null) {
+                return Optional.of(arg);
+            }
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * Shared logic for processing a resolved parameter expression (both positional and named
+     * parameters). Mirrors the inner body of the original analyseExpression loop.
+     */
+    private void processParameterExpression(
+            @Nonnull Parameter<Tree> parameter,
+            @Nonnull Tree expression,
+            @Nonnull CallExpression expressionTree) {
+        if (parameter.is(DetectableParameter.class)) {
+            DetectableParameter<Tree> detectableParameter = (DetectableParameter<Tree>) parameter;
+            // try to resolve value in inner scope
+            List<ResolvedValue<Object, Tree>> resolvedValues =
+                    resolveValuesInInnerScope(
+                            Object.class, expression, detectableParameter.getiValueFactory());
+            if (resolvedValues.isEmpty()) {
+                // goto outer scope
+                resolveValuesInOuterScope(expression, detectableParameter);
+            } else {
+                resolvedValues.stream()
+                        .map(
+                                resolvedValue ->
+                                        new ValueDetection<>(
+                                                resolvedValue,
+                                                detectableParameter,
+                                                expressionTree,
+                                                expressionTree))
+                        .forEach(detectionStore::onReceivingNewDetection);
+            }
+        } else if (!parameter.getDetectionRules().isEmpty()) {
+            /*
+             * This case is reached when the parameter is not a DetectableParameter (the rule does not contains `.shouldBeDetectedAs`),
+             * but has depending detection rules (the rule contain `.addDependingDetectionRules`).
+             * This happens usually for parameters that are intermediary function, that we have to resolve but we don't want to capture their value.
+             * In this case, we resolve the parameter with the depending detection rule with an EXPRESSION scope,
+             * this way we ensure to only resolve the right parameter content and not similar calls in the same function scope.
+             */
+            detectionStore.onDetectedDependingParameter(
+                    parameter, expression, DetectionStore.Scope.EXPRESSION);
         }
     }
 

--- a/engine/src/main/java/com/ibm/engine/language/python/PythonDetectionEngine.java
+++ b/engine/src/main/java/com/ibm/engine/language/python/PythonDetectionEngine.java
@@ -363,9 +363,6 @@ public class PythonDetectionEngine implements IDetectionEngine<Tree, Symbol> {
             Optional<Argument> resolved =
                     findArgumentByKeyword(keywordName.get(), parameter.getIndex(), arguments);
             if (resolved.isEmpty()) {
-                if (parameter.isKeywordOptional()) {
-                    return Optional.of(TraceSymbol.createWithStateDifferent());
-                }
                 return Optional.of(TraceSymbol.createWithStateDifferent());
             }
             Argument arg = resolved.get();
@@ -486,6 +483,22 @@ public class PythonDetectionEngine implements IDetectionEngine<Tree, Symbol> {
             if (hasUnknownKeyword) {
                 return;
             }
+
+            // Reject if any required named parameter is absent from the call site.
+            // This must run before MethodDetection is emitted so that a call that is missing a
+            // required argument produces no finding at all (not just a missing child detection).
+            int preCheckIndex = 0;
+            for (Parameter<Tree> p : detectionRule.parameters()) {
+                if (p.getKeywordName().isPresent() && !p.isKeywordOptional()) {
+                    Optional<Argument> present =
+                            findArgumentByKeyword(
+                                    p.getKeywordName().get(), preCheckIndex, arguments);
+                    if (present.isEmpty()) {
+                        return;
+                    }
+                }
+                preCheckIndex++;
+            }
         }
 
         if (detectionRule.actionFactory() != null) {
@@ -512,7 +525,9 @@ public class PythonDetectionEngine implements IDetectionEngine<Tree, Symbol> {
                         positionalIndex++;
                         continue;
                     } else {
-                        // required named parameter absent → rule does not fire; stop processing
+                        // required named parameter absent → stop processing
+                        // (pre-flight at line 490 already guarantees this branch is unreachable
+                        // for named parameters; kept as a defensive fallback)
                         return;
                     }
                 }
@@ -561,8 +576,7 @@ public class PythonDetectionEngine implements IDetectionEngine<Tree, Symbol> {
                     }
                 }
 
-                if (!checkCurrentIndexState(
-                        positionalIndex, arguments, isInvocation, traceSymbol, expressionTree)) {
+                if (!checkSymbolTraceState(isInvocation, traceSymbol, expressionTree)) {
                     positionalIndex++;
                     continue;
                 }
@@ -675,6 +689,19 @@ public class PythonDetectionEngine implements IDetectionEngine<Tree, Symbol> {
             return false;
         }
 
+        return checkSymbolTraceState(isInvocation, traceSymbol, expressionTree);
+    }
+
+    /**
+     * Checks whether the call-graph symbol-trace context allows the rule to fire. This is the
+     * second half of {@link #checkCurrentIndexState} without the arity guard, and is used on the
+     * named-parameter path where the argument has already been resolved by keyword name and its
+     * physical existence is guaranteed by {@link #findArgumentByKeyword}.
+     */
+    private boolean checkSymbolTraceState(
+            boolean isInvocation,
+            @Nonnull TraceSymbol<Symbol> traceSymbol,
+            @Nonnull CallExpression expressionTree) {
         // Check if the variable symbols for the method (if applicable) are connected
         Optional<Symbol> assignedSymbol =
                 getAssignedSymbol(expressionTree).map(ts -> ts.getSymbol());

--- a/engine/src/main/java/com/ibm/engine/language/python/PythonDetectionEngine.java
+++ b/engine/src/main/java/com/ibm/engine/language/python/PythonDetectionEngine.java
@@ -32,8 +32,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.slf4j.Logger;
@@ -467,19 +466,32 @@ public class PythonDetectionEngine implements IDetectionEngine<Tree, Symbol> {
                 return;
             }
 
-            // Reject if any keyword argument name is not declared in the rule.
-            Set<String> declaredKeywordNames =
-                    detectionRule.parameters().stream()
-                            .flatMap(p -> p.getKeywordName().stream())
-                            .collect(Collectors.toSet());
+            // Reject if any keyword argument does not match any rule parameter — neither by
+            // keyword name nor by positional index. The index check handles mixed rules where a
+            // leading withMethodParameter slot is passed by name at the call site, which Python
+            // allows.
+            List<Parameter<Tree>> params = detectionRule.parameters();
             boolean hasUnknownKeyword =
-                    arguments.stream()
+                    IntStream.range(0, arguments.size())
                             .anyMatch(
-                                    a ->
-                                            a instanceof RegularArgument ra
-                                                    && ra.keywordArgument() != null
-                                                    && !declaredKeywordNames.contains(
-                                                            ra.keywordArgument().name()));
+                                    i -> {
+                                        Argument a = arguments.get(i);
+                                        if (!(a instanceof RegularArgument ra)
+                                                || ra.keywordArgument() == null) {
+                                            return false;
+                                        }
+                                        String name = ra.keywordArgument().name();
+                                        return params.stream()
+                                                .noneMatch(
+                                                        p ->
+                                                                p.getKeywordName()
+                                                                                .map(name::equals)
+                                                                                .orElse(false)
+                                                                        || (p.getKeywordName()
+                                                                                        .isEmpty()
+                                                                                && p.getIndex()
+                                                                                        == i));
+                                    });
             if (hasUnknownKeyword) {
                 return;
             }
@@ -487,17 +499,15 @@ public class PythonDetectionEngine implements IDetectionEngine<Tree, Symbol> {
             // Reject if any required named parameter is absent from the call site.
             // This must run before MethodDetection is emitted so that a call that is missing a
             // required argument produces no finding at all (not just a missing child detection).
-            int preCheckIndex = 0;
             for (Parameter<Tree> p : detectionRule.parameters()) {
                 if (p.getKeywordName().isPresent() && !p.isKeywordOptional()) {
                     Optional<Argument> present =
                             findArgumentByKeyword(
-                                    p.getKeywordName().get(), preCheckIndex, arguments);
+                                    p.getKeywordName().get(), p.getIndex(), arguments);
                     if (present.isEmpty()) {
                         return;
                     }
                 }
-                preCheckIndex++;
             }
         }
 
@@ -509,24 +519,22 @@ public class PythonDetectionEngine implements IDetectionEngine<Tree, Symbol> {
         // Track whether a preceding optional named parameter was skipped (Hole 1 mitigation).
         boolean precedingOptionalNamedParamWasSkipped = false;
 
-        int positionalIndex = 0; // tracks the index among all parameters (for positional fallback)
         for (Parameter<Tree> parameter : detectionRule.parameters()) {
             Optional<String> keywordName = parameter.getKeywordName();
 
             if (keywordName.isPresent()) {
                 // --- Named parameter extraction (proposal §3) ---
                 Optional<Argument> resolvedArg =
-                        findArgumentByKeyword(keywordName.get(), positionalIndex, arguments);
+                        findArgumentByKeyword(keywordName.get(), parameter.getIndex(), arguments);
 
                 if (resolvedArg.isEmpty()) {
                     if (parameter.isKeywordOptional()) {
                         // optional parameter absent → skip silently
                         precedingOptionalNamedParamWasSkipped = true;
-                        positionalIndex++;
                         continue;
                     } else {
                         // required named parameter absent → stop processing
-                        // (pre-flight at line 490 already guarantees this branch is unreachable
+                        // (pre-flight already guarantees this branch is unreachable
                         // for named parameters; kept as a defensive fallback)
                         return;
                     }
@@ -538,15 +546,16 @@ public class PythonDetectionEngine implements IDetectionEngine<Tree, Symbol> {
                 boolean usedPositionalFallback =
                         (arg instanceof RegularArgument ra && ra.keywordArgument() == null);
                 if (usedPositionalFallback && precedingOptionalNamedParamWasSkipped) {
-                    LOG.warn(
+                    LOG.debug(
                             "Named parameter \"{}\" resolved via positional fallback at index {},"
                                     + " but a preceding optional named parameter was not found."
                                     + " The positional argument may belong to a different parameter."
-                                    + " Rule: {}, location: {}",
+                                    + " File: {}, line: {}, column: {}",
                             keywordName.get(),
-                            positionalIndex,
-                            detectionStore.getDetectionRule().getClass().getSimpleName(),
-                            expressionTree.firstToken().value());
+                            parameter.getIndex(),
+                            detectionStore.getScanContext().getRelativePath(),
+                            expressionTree.firstToken().line(),
+                            expressionTree.firstToken().column());
                 }
 
                 // extract expression from the resolved argument
@@ -567,7 +576,6 @@ public class PythonDetectionEngine implements IDetectionEngine<Tree, Symbol> {
                         if (parameter.isKeywordOptional()) {
                             // Type mismatch on an optional param: treat as absent and skip.
                             precedingOptionalNamedParamWasSkipped = true;
-                            positionalIndex++;
                             continue;
                         } else {
                             // Type mismatch on a required param: rule does not fire.
@@ -577,7 +585,6 @@ public class PythonDetectionEngine implements IDetectionEngine<Tree, Symbol> {
                 }
 
                 if (!checkSymbolTraceState(isInvocation, traceSymbol, expressionTree)) {
-                    positionalIndex++;
                     continue;
                 }
 
@@ -585,19 +592,20 @@ public class PythonDetectionEngine implements IDetectionEngine<Tree, Symbol> {
             } else {
                 // --- Positional parameter extraction (original behaviour) ---
                 if (!checkCurrentIndexState(
-                        positionalIndex, arguments, isInvocation, traceSymbol, expressionTree)) {
-                    positionalIndex++;
+                        parameter.getIndex(),
+                        arguments,
+                        isInvocation,
+                        traceSymbol,
+                        expressionTree)) {
                     continue;
                 }
-                Tree expression = arguments.get(positionalIndex);
+                Tree expression = arguments.get(parameter.getIndex());
                 if (expression instanceof RegularArgument regularArgument) {
                     expression = regularArgument.expression();
                 }
 
                 processParameterExpression(parameter, expression, expressionTree);
             }
-
-            positionalIndex++;
         }
     }
 

--- a/engine/src/main/java/com/ibm/engine/rule/DetectableParameter.java
+++ b/engine/src/main/java/com/ibm/engine/rule/DetectableParameter.java
@@ -41,7 +41,30 @@ public class DetectableParameter<T> extends Parameter<T> {
                 parameterType,
                 index,
                 shouldMatchExactTypes,
-                detectionRules);
+                detectionRules,
+                null,
+                false);
+        this.iValueFactory = iValueFactory;
+        this.shouldBeMovedUnder = shouldBeMovedUnder;
+    }
+
+    public DetectableParameter(
+            @Nonnull String parameterType,
+            int index,
+            boolean shouldMatchExactTypes,
+            @Nonnull IValueFactory<T> iValueFactory,
+            @Nonnull List<IDetectionRule<T>> detectionRules,
+            @Nullable Integer shouldBeMovedUnder,
+            @Nullable String keywordName,
+            boolean keywordOptional) {
+        super(
+                DetectableParameter.class,
+                parameterType,
+                index,
+                shouldMatchExactTypes,
+                detectionRules,
+                keywordName,
+                keywordOptional);
         this.iValueFactory = iValueFactory;
         this.shouldBeMovedUnder = shouldBeMovedUnder;
     }

--- a/engine/src/main/java/com/ibm/engine/rule/IDetectionRule.java
+++ b/engine/src/main/java/com/ibm/engine/rule/IDetectionRule.java
@@ -72,6 +72,10 @@ public interface IDetectionRule<T> {
 
         @Nonnull
         ParametersFactoryBuilder<T> withMethodParameterMatchExactType(@Nonnull String type);
+
+        @Nonnull
+        ParametersFactoryBuilder<T> withNamedMethodParameter(
+                @Nonnull String name, @Nonnull String type, boolean optional);
     }
 
     interface ParametersTypeBuilder<T> {
@@ -80,6 +84,10 @@ public interface IDetectionRule<T> {
 
         @Nonnull
         ParametersFactoryBuilder<T> withMethodParameterMatchExactType(@Nonnull String type);
+
+        @Nonnull
+        ParametersFactoryBuilder<T> withNamedMethodParameter(
+                @Nonnull String name, @Nonnull String type, boolean optional);
 
         @Nonnull
         FinalDetectionRuleBuilder<T> withoutParameters();
@@ -94,6 +102,10 @@ public interface IDetectionRule<T> {
 
         @Nonnull
         ParametersFactoryBuilder<T> withMethodParameterMatchExactType(@Nonnull String type);
+
+        @Nonnull
+        ParametersFactoryBuilder<T> withNamedMethodParameter(
+                @Nonnull String name, @Nonnull String type, boolean optional);
 
         @Nonnull
         PositionBuilder<T> shouldBeDetectedAs(@Nonnull IValueFactory<T> valueFactory);
@@ -115,6 +127,10 @@ public interface IDetectionRule<T> {
         ParametersFactoryBuilder<T> withMethodParameterMatchExactType(@Nonnull String type);
 
         @Nonnull
+        ParametersFactoryBuilder<T> withNamedMethodParameter(
+                @Nonnull String name, @Nonnull String type, boolean optional);
+
+        @Nonnull
         ParametersDependingRulesBuilder<T> asChildOfParameterWithId(int id);
 
         @Nonnull
@@ -134,6 +150,10 @@ public interface IDetectionRule<T> {
         ParametersFactoryBuilder<T> withMethodParameterMatchExactType(@Nonnull String type);
 
         @Nonnull
+        ParametersFactoryBuilder<T> withNamedMethodParameter(
+                @Nonnull String name, @Nonnull String type, boolean optional);
+
+        @Nonnull
         ParametersFinalDetectionRuleBuilder<T> addDependingDetectionRules(
                 @Nonnull List<IDetectionRule<T>> detectionRules);
 
@@ -148,6 +168,10 @@ public interface IDetectionRule<T> {
 
         @Nonnull
         ParametersFactoryBuilder<T> withMethodParameterMatchExactType(@Nonnull String type);
+
+        @Nonnull
+        ParametersFactoryBuilder<T> withNamedMethodParameter(
+                @Nonnull String name, @Nonnull String type, boolean optional);
 
         @Nonnull
         AddBundleDetectionRuleBuilder<T> buildForContext(

--- a/engine/src/main/java/com/ibm/engine/rule/Parameter.java
+++ b/engine/src/main/java/com/ibm/engine/rule/Parameter.java
@@ -20,7 +20,9 @@
 package com.ibm.engine.rule;
 
 import java.util.List;
+import java.util.Optional;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 public class Parameter<T> {
     @Nonnull protected final List<IDetectionRule<T>> detectionRules;
@@ -29,17 +31,27 @@ public class Parameter<T> {
     protected boolean shouldMatchExactTypes;
     protected final int index;
 
+    /** Non-null when this parameter was declared with {@code withNamedMethodParameter}. */
+    @Nullable private final String keywordName;
+
+    /** True when this named parameter may be absent from the call site. */
+    private final boolean keywordOptional;
+
     protected Parameter(
             @Nonnull Class<? extends Parameter> type,
             @Nonnull String parameterType,
             int index,
             boolean shouldMatchExactTypes,
-            @Nonnull List<IDetectionRule<T>> detectionRules) {
+            @Nonnull List<IDetectionRule<T>> detectionRules,
+            @Nullable String keywordName,
+            boolean keywordOptional) {
         this.type = type;
         this.parameterType = parameterType;
         this.index = index;
         this.shouldMatchExactTypes = shouldMatchExactTypes;
         this.detectionRules = detectionRules;
+        this.keywordName = keywordName;
+        this.keywordOptional = keywordOptional;
     }
 
     public Parameter(
@@ -52,6 +64,24 @@ public class Parameter<T> {
         this.index = index;
         this.shouldMatchExactTypes = shouldMatchExactTypes;
         this.detectionRules = detectionRules;
+        this.keywordName = null;
+        this.keywordOptional = false;
+    }
+
+    public Parameter(
+            @Nonnull String parameterType,
+            int index,
+            boolean shouldMatchExactTypes,
+            @Nonnull List<IDetectionRule<T>> detectionRules,
+            @Nullable String keywordName,
+            boolean keywordOptional) {
+        this.type = Parameter.class;
+        this.parameterType = parameterType;
+        this.index = index;
+        this.shouldMatchExactTypes = shouldMatchExactTypes;
+        this.detectionRules = detectionRules;
+        this.keywordName = keywordName;
+        this.keywordOptional = keywordOptional;
     }
 
     public boolean is(@Nonnull Class<? extends Parameter> type) {
@@ -74,5 +104,19 @@ public class Parameter<T> {
     @Nonnull
     public List<IDetectionRule<T>> getDetectionRules() {
         return detectionRules;
+    }
+
+    /** Returns the keyword-argument name if this is a named parameter, otherwise empty. */
+    @Nonnull
+    public Optional<String> getKeywordName() {
+        return Optional.ofNullable(keywordName);
+    }
+
+    /**
+     * Returns {@code true} when this is a named parameter that may be absent at the call site
+     * without preventing a match.
+     */
+    public boolean isKeywordOptional() {
+        return keywordOptional;
     }
 }

--- a/engine/src/main/java/com/ibm/engine/rule/builder/DetectionRuleBuilderImpl.java
+++ b/engine/src/main/java/com/ibm/engine/rule/builder/DetectionRuleBuilderImpl.java
@@ -50,6 +50,12 @@ final class DetectionRuleBuilderImpl<T>
     @Nullable private IBundle bundle;
     private boolean shouldMatchExactTypes;
 
+    /**
+     * Set to {@code true} as soon as the first {@code withNamedMethodParameter} call is made.
+     * Subsequent {@code withMethodParameter} calls after this point are illegal.
+     */
+    private boolean namedParameterAdded;
+
     @Nonnull
     private LinkedList<IDetectionRule<T>> invokedObjectDependingDetectionRules = new LinkedList<>();
 
@@ -61,12 +67,16 @@ final class DetectionRuleBuilderImpl<T>
     @Nonnull private LinkedList<IDetectionRule<T>> detectionRules = new LinkedList<>();
     @Nullable private Integer positionMove;
     private boolean parameterShouldMatchExactTypes;
+    // named-parameter fields for the parameter currently being assembled
+    @Nullable private String pendingKeywordName;
+    private boolean pendingKeywordOptional;
 
     public DetectionRuleBuilderImpl() {
         // nothing
         buildingNewDetectionParameter = false;
         shouldMatchExactTypes = false;
         parameterShouldMatchExactTypes = false;
+        namedParameterAdded = false;
     }
 
     @SuppressWarnings("all")
@@ -85,7 +95,10 @@ final class DetectionRuleBuilderImpl<T>
             @Nullable Integer positionMove,
             boolean parameterShouldMatchExactTypes,
             boolean buildingNewDetectionParameter,
-            @Nullable IBundle bundle) {
+            @Nullable IBundle bundle,
+            boolean namedParameterAdded,
+            @Nullable String pendingKeywordName,
+            boolean pendingKeywordOptional) {
         this.objectTypes = objectTypes;
         this.methodNames = methodNames;
         this.parameters = parameters;
@@ -104,12 +117,13 @@ final class DetectionRuleBuilderImpl<T>
         this.buildingNewDetectionParameter = buildingNewDetectionParameter;
 
         this.bundle = bundle;
+        this.namedParameterAdded = namedParameterAdded;
+        this.pendingKeywordName = pendingKeywordName;
+        this.pendingKeywordOptional = pendingKeywordOptional;
     }
 
     @Nonnull
-    @Override
-    public IDetectionRule.NameBuilder<T> forObjectTypes(@Nonnull String... types) {
-        this.objectTypes = types;
+    private DetectionRuleBuilderImpl<T> copy() {
         return new DetectionRuleBuilderImpl<>(
                 objectTypes,
                 methodNames,
@@ -125,7 +139,17 @@ final class DetectionRuleBuilderImpl<T>
                 positionMove,
                 parameterShouldMatchExactTypes,
                 buildingNewDetectionParameter,
-                bundle);
+                bundle,
+                namedParameterAdded,
+                pendingKeywordName,
+                pendingKeywordOptional);
+    }
+
+    @Nonnull
+    @Override
+    public IDetectionRule.NameBuilder<T> forObjectTypes(@Nonnull String... types) {
+        this.objectTypes = types;
+        return copy();
     }
 
     @Nonnull
@@ -133,44 +157,14 @@ final class DetectionRuleBuilderImpl<T>
     public IDetectionRule.NameBuilder<T> forObjectExactTypes(@Nonnull String... types) {
         this.objectTypes = types;
         this.shouldMatchExactTypes = true;
-        return new DetectionRuleBuilderImpl<>(
-                objectTypes,
-                methodNames,
-                parameters,
-                capturedParameterScope,
-                detectionValueContext,
-                shouldMatchExactTypes,
-                invokedObjectDependingDetectionRules,
-                parameterType,
-                iValueFactory,
-                iActionFactory,
-                detectionRules,
-                positionMove,
-                parameterShouldMatchExactTypes,
-                buildingNewDetectionParameter,
-                bundle);
+        return copy();
     }
 
     @Nonnull
     @Override
     public IDetectionRule.ActionDetectionBuilder<T> forMethods(@Nonnull String... names) {
         this.methodNames = names;
-        return new DetectionRuleBuilderImpl<>(
-                objectTypes,
-                methodNames,
-                parameters,
-                capturedParameterScope,
-                detectionValueContext,
-                shouldMatchExactTypes,
-                invokedObjectDependingDetectionRules,
-                parameterType,
-                iValueFactory,
-                iActionFactory,
-                detectionRules,
-                positionMove,
-                parameterShouldMatchExactTypes,
-                buildingNewDetectionParameter,
-                bundle);
+        return copy();
     }
 
     @Nonnull
@@ -178,140 +172,72 @@ final class DetectionRuleBuilderImpl<T>
     public IDetectionRule.ActionDetectionBuilder<T> forConstructor() {
         this.methodNames = new String[1];
         this.methodNames[0] = "<init>";
-        return new DetectionRuleBuilderImpl<>(
-                objectTypes,
-                methodNames,
-                parameters,
-                capturedParameterScope,
-                detectionValueContext,
-                shouldMatchExactTypes,
-                invokedObjectDependingDetectionRules,
-                parameterType,
-                iValueFactory,
-                iActionFactory,
-                detectionRules,
-                positionMove,
-                parameterShouldMatchExactTypes,
-                buildingNewDetectionParameter,
-                bundle);
+        return copy();
     }
 
     @Nonnull
     public IDetectionRule.ParametersTypeBuilder<T> shouldBeDetectedAs(
             @Nonnull IActionFactory<T> actionFactory) {
         this.iActionFactory = actionFactory;
-        return new DetectionRuleBuilderImpl<>(
-                objectTypes,
-                methodNames,
-                parameters,
-                capturedParameterScope,
-                detectionValueContext,
-                shouldMatchExactTypes,
-                invokedObjectDependingDetectionRules,
-                parameterType,
-                iValueFactory,
-                iActionFactory,
-                detectionRules,
-                positionMove,
-                parameterShouldMatchExactTypes,
-                buildingNewDetectionParameter,
-                bundle);
+        return copy();
     }
 
     @Nonnull
     @Override
     public IDetectionRule.ParametersFactoryBuilder<T> withMethodParameter(@Nonnull String type) {
+        if (namedParameterAdded) {
+            throw new IllegalStateException(
+                    "withMethodParameter() must precede all withNamedMethodParameter() declarations.");
+        }
         checkDetectionParameterState();
         this.buildingNewDetectionParameter = false;
         this.capturedParameterScope = CapturedParameterScope.SOME;
         this.parameterType = type;
-        return new DetectionRuleBuilderImpl<>(
-                objectTypes,
-                methodNames,
-                parameters,
-                capturedParameterScope,
-                detectionValueContext,
-                shouldMatchExactTypes,
-                invokedObjectDependingDetectionRules,
-                parameterType,
-                iValueFactory,
-                iActionFactory,
-                detectionRules,
-                positionMove,
-                parameterShouldMatchExactTypes,
-                buildingNewDetectionParameter,
-                bundle);
+        return copy();
     }
 
     @Nonnull
     @Override
     public IDetectionRule.ParametersFactoryBuilder<T> withMethodParameterMatchExactType(
             @Nonnull String type) {
+        if (namedParameterAdded) {
+            throw new IllegalStateException(
+                    "withMethodParameterMatchExactType() must precede all withNamedMethodParameter() declarations.");
+        }
         checkDetectionParameterState();
         this.buildingNewDetectionParameter = false;
         this.capturedParameterScope = CapturedParameterScope.SOME;
         this.parameterType = type;
         this.parameterShouldMatchExactTypes = true;
-        return new DetectionRuleBuilderImpl<>(
-                objectTypes,
-                methodNames,
-                parameters,
-                capturedParameterScope,
-                detectionValueContext,
-                shouldMatchExactTypes,
-                invokedObjectDependingDetectionRules,
-                parameterType,
-                iValueFactory,
-                iActionFactory,
-                detectionRules,
-                positionMove,
-                parameterShouldMatchExactTypes,
-                buildingNewDetectionParameter,
-                bundle);
+        return copy();
+    }
+
+    @Nonnull
+    @Override
+    public IDetectionRule.ParametersFactoryBuilder<T> withNamedMethodParameter(
+            @Nonnull String name, @Nonnull String type, boolean optional) {
+        checkDetectionParameterState();
+        this.buildingNewDetectionParameter = false;
+        this.capturedParameterScope = CapturedParameterScope.SOME;
+        this.parameterType = type;
+        this.namedParameterAdded = true;
+        this.pendingKeywordName = name;
+        this.pendingKeywordOptional = optional;
+        return copy();
     }
 
     @Nonnull
     @Override
     public IDetectionRule.FinalDetectionRuleBuilder<T> withoutParameters() {
         capturedParameterScope = CapturedParameterScope.NONE;
-        return new DetectionRuleBuilderImpl<>(
-                objectTypes,
-                methodNames,
-                parameters,
-                capturedParameterScope,
-                detectionValueContext,
-                shouldMatchExactTypes,
-                invokedObjectDependingDetectionRules,
-                parameterType,
-                iValueFactory,
-                iActionFactory,
-                detectionRules,
-                positionMove,
-                parameterShouldMatchExactTypes,
-                buildingNewDetectionParameter,
-                bundle);
+        return copy();
     }
 
     @Nonnull
     @Override
     public IDetectionRule.FinalDetectionRuleBuilder<T> withAnyParameters() {
         capturedParameterScope = CapturedParameterScope.ANY;
-        return new DetectionRuleBuilderImpl<>(
-                objectTypes,
-                methodNames,
-                parameters,
-                capturedParameterScope,
-                detectionValueContext,
-                shouldMatchExactTypes,
-                invokedObjectDependingDetectionRules,
-                parameterType,
-                iValueFactory,
-                iActionFactory,
-                detectionRules,
-                positionMove,
-                parameterShouldMatchExactTypes,
-                buildingNewDetectionParameter,
-                bundle);
+        return copy();
     }
 
     @Nonnull
@@ -319,22 +245,7 @@ final class DetectionRuleBuilderImpl<T>
     public IDetectionRule.ParametersDependingRulesBuilder<T> asChildOfParameterWithId(int id) {
         this.buildingNewDetectionParameter = true;
         this.positionMove = id;
-        return new DetectionRuleBuilderImpl<>(
-                objectTypes,
-                methodNames,
-                parameters,
-                capturedParameterScope,
-                detectionValueContext,
-                shouldMatchExactTypes,
-                invokedObjectDependingDetectionRules,
-                parameterType,
-                iValueFactory,
-                iActionFactory,
-                detectionRules,
-                positionMove,
-                parameterShouldMatchExactTypes,
-                buildingNewDetectionParameter,
-                bundle);
+        return copy();
     }
 
     @Nonnull
@@ -342,22 +253,7 @@ final class DetectionRuleBuilderImpl<T>
     public IDetectionRule.AddBundleDetectionRuleBuilder<T> buildForContext(
             @Nonnull IDetectionContext detectionValueContext) {
         this.detectionValueContext = detectionValueContext;
-        return new DetectionRuleBuilderImpl<>(
-                objectTypes,
-                methodNames,
-                parameters,
-                capturedParameterScope,
-                detectionValueContext,
-                shouldMatchExactTypes,
-                invokedObjectDependingDetectionRules,
-                parameterType,
-                iValueFactory,
-                iActionFactory,
-                detectionRules,
-                positionMove,
-                parameterShouldMatchExactTypes,
-                buildingNewDetectionParameter,
-                bundle);
+        return copy();
     }
 
     @Nonnull
@@ -381,7 +277,10 @@ final class DetectionRuleBuilderImpl<T>
                 positionMove,
                 parameterShouldMatchExactTypes,
                 buildingNewDetectionParameter,
-                bundle);
+                bundle,
+                namedParameterAdded,
+                pendingKeywordName,
+                pendingKeywordOptional);
     }
 
     @Nonnull
@@ -390,22 +289,7 @@ final class DetectionRuleBuilderImpl<T>
             @Nonnull IValueFactory<T> valueFactory) {
         this.buildingNewDetectionParameter = true;
         this.iValueFactory = valueFactory;
-        return new DetectionRuleBuilderImpl<>(
-                objectTypes,
-                methodNames,
-                parameters,
-                capturedParameterScope,
-                detectionValueContext,
-                shouldMatchExactTypes,
-                invokedObjectDependingDetectionRules,
-                parameterType,
-                iValueFactory,
-                iActionFactory,
-                detectionRules,
-                positionMove,
-                parameterShouldMatchExactTypes,
-                buildingNewDetectionParameter,
-                bundle);
+        return copy();
     }
 
     @Nonnull
@@ -413,22 +297,7 @@ final class DetectionRuleBuilderImpl<T>
     public IDetectionRule.InvokedObjectDependingDetectionRules<T> inBundle(
             @Nonnull IBundle bundle) {
         this.bundle = bundle;
-        return new DetectionRuleBuilderImpl<>(
-                objectTypes,
-                methodNames,
-                parameters,
-                capturedParameterScope,
-                detectionValueContext,
-                shouldMatchExactTypes,
-                invokedObjectDependingDetectionRules,
-                parameterType,
-                iValueFactory,
-                iActionFactory,
-                detectionRules,
-                positionMove,
-                parameterShouldMatchExactTypes,
-                buildingNewDetectionParameter,
-                bundle);
+        return copy();
     }
 
     @Nonnull
@@ -485,11 +354,21 @@ final class DetectionRuleBuilderImpl<T>
                     bundle,
                     invokedObjectDependingDetectionRules);
         } else {
-            final MethodMatcher<T> methodMatcher =
-                    new MethodMatcher<>(
-                            this.objectTypes,
-                            this.methodNames,
-                            this.parameters.stream().map(Parameter::getParameterType).toList());
+            // If any parameter is a named parameter, use the no-type-list MethodMatcher so that
+            // the matcher accepts any call to the method and delegates structural matching to
+            // the extraction loop in the engine (proposal §2.1).
+            final boolean hasNamedParams =
+                    parameters.stream().anyMatch(p -> p.getKeywordName().isPresent());
+            final MethodMatcher<T> methodMatcher;
+            if (hasNamedParams) {
+                methodMatcher = new MethodMatcher<>(this.objectTypes, this.methodNames);
+            } else {
+                methodMatcher =
+                        new MethodMatcher<>(
+                                this.objectTypes,
+                                this.methodNames,
+                                this.parameters.stream().map(Parameter::getParameterType).toList());
+            }
 
             return new DetectionRule<>(
                     methodMatcher,
@@ -516,22 +395,49 @@ final class DetectionRuleBuilderImpl<T>
                                 parameterShouldMatchExactTypes,
                                 detectionRules));
             } else {
+                if (pendingKeywordName != null) {
+                    this.parameters.add(
+                            new DetectableParameter<>(
+                                    parameterType,
+                                    this.parameters.size(),
+                                    parameterShouldMatchExactTypes,
+                                    iValueFactory,
+                                    detectionRules,
+                                    positionMove,
+                                    pendingKeywordName,
+                                    pendingKeywordOptional));
+                } else {
+                    this.parameters.add(
+                            new DetectableParameter<>(
+                                    parameterType,
+                                    this.parameters.size(),
+                                    parameterShouldMatchExactTypes,
+                                    iValueFactory,
+                                    detectionRules,
+                                    positionMove));
+                }
+            }
+        } else {
+            if (pendingKeywordName != null) {
+                // Named parameter without .shouldBeDetectedAs() — store as a plain Parameter
+                // with keyword metadata so the engine can do keyword-name lookup / positional
+                // fallback without capturing a value.
                 this.parameters.add(
-                        new DetectableParameter<>(
+                        new Parameter<>(
                                 parameterType,
                                 this.parameters.size(),
                                 parameterShouldMatchExactTypes,
-                                iValueFactory,
                                 detectionRules,
-                                positionMove));
+                                pendingKeywordName,
+                                pendingKeywordOptional));
+            } else {
+                this.parameters.add(
+                        new Parameter<>(
+                                parameterType,
+                                this.parameters.size(),
+                                parameterShouldMatchExactTypes,
+                                List.of()));
             }
-        } else {
-            this.parameters.add(
-                    new Parameter<>(
-                            parameterType,
-                            this.parameters.size(),
-                            parameterShouldMatchExactTypes,
-                            List.of()));
         }
 
         this.parameterType = null;
@@ -539,6 +445,8 @@ final class DetectionRuleBuilderImpl<T>
         this.detectionRules = new LinkedList<>();
         this.positionMove = null;
         this.parameterShouldMatchExactTypes = false;
+        this.pendingKeywordName = null;
+        this.pendingKeywordOptional = false;
     }
 
     enum CapturedParameterScope {

--- a/python/src/main/java/com/ibm/plugin/rules/detection/pycrypto/hash/PycryptoCryptoHash.java
+++ b/python/src/main/java/com/ibm/plugin/rules/detection/pycrypto/hash/PycryptoCryptoHash.java
@@ -1,0 +1,91 @@
+/*
+ * Sonar Cryptography Plugin
+ * Copyright (C) 2024 PQCA
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ibm.plugin.rules.detection.pycrypto.hash;
+
+import static com.ibm.engine.detection.MethodMatcher.ANY;
+
+import com.ibm.engine.model.AlgorithmParameter;
+import com.ibm.engine.model.context.DigestContext;
+import com.ibm.engine.model.factory.AlgorithmParameterFactory;
+import com.ibm.engine.model.factory.ValueActionFactory;
+import com.ibm.engine.rule.IDetectionRule;
+import com.ibm.engine.rule.builder.DetectionRuleBuilder;
+import com.ibm.plugin.rules.detection.Memoize;
+import java.util.List;
+import java.util.function.Supplier;
+import javax.annotation.Nonnull;
+import org.sonar.plugins.python.api.tree.Tree;
+
+/**
+ * Detection rules for PyCrypto / PyCryptodome hash functions that use the {@code .new()} factory
+ * pattern (e.g. {@code Crypto.Hash.SHA512.new(data=b"...", truncate="256")}).
+ *
+ * <p>SHA512.new(data=None, truncate=None)
+ *
+ * <ul>
+ *   <li>{@code data} — optional bytes to hash; ANY type, optional
+ *   <li>{@code truncate} — optional truncation variant ("256" or "224"); type {@code str}, optional
+ * </ul>
+ *
+ * <p>Both parameters are declared with {@code withNamedMethodParameter} so that keyword-argument
+ * call sites (e.g. {@code SHA512.new(truncate="256")}) are handled correctly regardless of argument
+ * order. The {@code truncate} value is captured as an {@link AlgorithmParameter} so that the
+ * truncated variant (SHA-512/256 or SHA-512/224) can be reported.
+ */
+@SuppressWarnings("java:S1192")
+public final class PycryptoCryptoHash {
+
+    private PycryptoCryptoHash() {
+        // private
+    }
+
+    /*
+     * SHA512.new(data=None, truncate=None)
+     *
+     * Both Crypto and Cryptodome are supported (identical API).
+     */
+    private static final IDetectionRule<Tree> SHA512_NEW =
+            new DetectionRuleBuilder<Tree>()
+                    .createDetectionRule()
+                    .forObjectTypes("Crypto.Hash.SHA512", "Cryptodome.Hash.SHA512")
+                    .forMethods("new")
+                    .shouldBeDetectedAs(new ValueActionFactory<>("SHA512"))
+                    .withNamedMethodParameter("data", ANY, /* optional */ true)
+                    .withNamedMethodParameter("truncate", "str", /* optional */ true)
+                    .shouldBeDetectedAs(
+                            new AlgorithmParameterFactory<>(AlgorithmParameter.Kind.ANY))
+                    .asChildOfParameterWithId(0)
+                    .buildForContext(new DigestContext())
+                    .inBundle(() -> "PyCrypto")
+                    .withoutDependingDetectionRules();
+
+    private static final Supplier<List<IDetectionRule<Tree>>> RULES =
+            Memoize.of(PycryptoCryptoHash::buildRules);
+
+    @Nonnull
+    public static List<IDetectionRule<Tree>> rules() {
+        return RULES.get();
+    }
+
+    @Nonnull
+    private static List<IDetectionRule<Tree>> buildRules() {
+        return List.of(SHA512_NEW);
+    }
+}

--- a/python/src/test/files/rules/detection/pycrypto/hash/SHA512NewBothKeywordsCanonicalOrderTest.py
+++ b/python/src/test/files/rules/detection/pycrypto/hash/SHA512NewBothKeywordsCanonicalOrderTest.py
@@ -1,0 +1,4 @@
+from Crypto.Hash import SHA512
+
+# SHA512.new(data=b"msg", truncate="256") — both by keyword name, canonical order
+h = SHA512.new(data=b"msg", truncate="256") # Noncompliant {{(MessageDigest) SHA-512}}

--- a/python/src/test/files/rules/detection/pycrypto/hash/SHA512NewBothKeywordsReorderedTest.py
+++ b/python/src/test/files/rules/detection/pycrypto/hash/SHA512NewBothKeywordsReorderedTest.py
@@ -1,0 +1,5 @@
+from Crypto.Hash import SHA512
+
+# SHA512.new(truncate="256", data=b"msg") — both by keyword name, reordered
+# truncate comes first but the rule must match both by keyword name regardless of order
+h = SHA512.new(truncate="256", data=b"msg") # Noncompliant {{(MessageDigest) SHA-512}}

--- a/python/src/test/files/rules/detection/pycrypto/hash/SHA512NewBothPositionalTest.py
+++ b/python/src/test/files/rules/detection/pycrypto/hash/SHA512NewBothPositionalTest.py
@@ -1,0 +1,4 @@
+from Crypto.Hash import SHA512
+
+# SHA512.new(b"msg", "256") — both by positional fallback (data→index 0, truncate→index 1)
+h = SHA512.new(b"msg", "256") # Noncompliant {{(MessageDigest) SHA-512}}

--- a/python/src/test/files/rules/detection/pycrypto/hash/SHA512NewCryptodomeTest.py
+++ b/python/src/test/files/rules/detection/pycrypto/hash/SHA512NewCryptodomeTest.py
@@ -1,0 +1,4 @@
+from Cryptodome.Hash import SHA512
+
+# Cryptodome variant — SHA512.new(data=b"msg", truncate="256")
+h = SHA512.new(data=b"msg", truncate="256") # Noncompliant {{(MessageDigest) SHA-512}}

--- a/python/src/test/files/rules/detection/pycrypto/hash/SHA512NewDataKeywordTest.py
+++ b/python/src/test/files/rules/detection/pycrypto/hash/SHA512NewDataKeywordTest.py
@@ -1,0 +1,4 @@
+from Crypto.Hash import SHA512
+
+# SHA512.new(data=b"msg") — data by keyword, truncate absent (optional)
+h = SHA512.new(data=b"msg") # Noncompliant {{(MessageDigest) SHA-512}}

--- a/python/src/test/files/rules/detection/pycrypto/hash/SHA512NewDataPositionalOnlyTest.py
+++ b/python/src/test/files/rules/detection/pycrypto/hash/SHA512NewDataPositionalOnlyTest.py
@@ -1,0 +1,4 @@
+from Crypto.Hash import SHA512
+
+# SHA512.new(b"msg") — data by positional fallback, truncate absent (optional)
+h = SHA512.new(b"msg") # Noncompliant {{(MessageDigest) SHA-512}}

--- a/python/src/test/files/rules/detection/pycrypto/hash/SHA512NewMixedPositionalKeywordTest.py
+++ b/python/src/test/files/rules/detection/pycrypto/hash/SHA512NewMixedPositionalKeywordTest.py
@@ -1,0 +1,4 @@
+from Crypto.Hash import SHA512
+
+# SHA512.new(b"msg", truncate="256") — data by positional fallback, truncate by keyword name
+h = SHA512.new(b"msg", truncate="256") # Noncompliant {{(MessageDigest) SHA-512}}

--- a/python/src/test/files/rules/detection/pycrypto/hash/SHA512NewNegativeDictUnpackTest.py
+++ b/python/src/test/files/rules/detection/pycrypto/hash/SHA512NewNegativeDictUnpackTest.py
@@ -1,0 +1,6 @@
+from Crypto.Hash import SHA512
+
+d = {"data": b"msg", "truncate": "256"}
+
+# SHA512.new(**d) — dict unpacking: contents cannot be statically inspected; must NOT be detected.
+h = SHA512.new(**d)

--- a/python/src/test/files/rules/detection/pycrypto/hash/SHA512NewNegativeDifferentAlgoTest.py
+++ b/python/src/test/files/rules/detection/pycrypto/hash/SHA512NewNegativeDifferentAlgoTest.py
@@ -1,0 +1,4 @@
+from Crypto.Hash import SHA256
+
+# SHA256.new() — different algorithm, should NOT be detected by the SHA512 rule
+h = SHA256.new()

--- a/python/src/test/files/rules/detection/pycrypto/hash/SHA512NewNegativeRequiredNamedParamAbsentTest.py
+++ b/python/src/test/files/rules/detection/pycrypto/hash/SHA512NewNegativeRequiredNamedParamAbsentTest.py
@@ -1,0 +1,5 @@
+from Crypto.Hash import SHA512
+
+# SHA512.new() — truncate is declared as required in this test's rule variant.
+# The rule must NOT fire because the required 'truncate' argument is absent.
+h = SHA512.new()

--- a/python/src/test/files/rules/detection/pycrypto/hash/SHA512NewNegativeSeqUnpackTest.py
+++ b/python/src/test/files/rules/detection/pycrypto/hash/SHA512NewNegativeSeqUnpackTest.py
@@ -1,0 +1,6 @@
+from Crypto.Hash import SHA512
+
+args = (b"msg", "256")
+
+# SHA512.new(*args) — sequence unpacking: contents cannot be statically inspected; must NOT be detected.
+h = SHA512.new(*args)

--- a/python/src/test/files/rules/detection/pycrypto/hash/SHA512NewNegativeWrongMethodTest.py
+++ b/python/src/test/files/rules/detection/pycrypto/hash/SHA512NewNegativeWrongMethodTest.py
@@ -1,0 +1,4 @@
+from Crypto.Hash import SHA512
+
+# SHA512.update() — wrong method name, should NOT be detected by the SHA512.new rule
+h = SHA512.update(b"msg")

--- a/python/src/test/files/rules/detection/pycrypto/hash/SHA512NewNegativeWrongTypeTest.py
+++ b/python/src/test/files/rules/detection/pycrypto/hash/SHA512NewNegativeWrongTypeTest.py
@@ -1,0 +1,7 @@
+from Crypto.Hash import SHA512
+
+# SHA512.new(truncate=256) — truncate is an int literal, but the rule declares type "str".
+# resolveTreeType resolves the literal statically; the type check rejects the truncate argument.
+# The optional truncate param is treated as absent: SHA512 is still detected, but without a
+# truncate child.
+h = SHA512.new(truncate=256) # Noncompliant {{(MessageDigest) SHA-512}}

--- a/python/src/test/files/rules/detection/pycrypto/hash/SHA512NewNoArgsTest.py
+++ b/python/src/test/files/rules/detection/pycrypto/hash/SHA512NewNoArgsTest.py
@@ -1,0 +1,4 @@
+from Crypto.Hash import SHA512
+
+# SHA512.new() — no arguments: both data and truncate absent (optional), rule must still match
+h = SHA512.new() # Noncompliant {{(MessageDigest) SHA-512}}

--- a/python/src/test/files/rules/detection/pycrypto/hash/SHA512NewTruncateKeywordOnlyTest.py
+++ b/python/src/test/files/rules/detection/pycrypto/hash/SHA512NewTruncateKeywordOnlyTest.py
@@ -1,0 +1,4 @@
+from Crypto.Hash import SHA512
+
+# SHA512.new(truncate="256") — truncate by keyword, data absent (optional)
+h = SHA512.new(truncate="256") # Noncompliant {{(MessageDigest) SHA-512}}

--- a/python/src/test/files/rules/detection/pycrypto/hash/SHA512NewUnknownKwargTest.py
+++ b/python/src/test/files/rules/detection/pycrypto/hash/SHA512NewUnknownKwargTest.py
@@ -1,0 +1,5 @@
+from Crypto.Hash import SHA512
+
+# SHA512.new(unknown_kwarg="value") — unknown keyword argument not declared in the rule;
+# the call does not match the known SHA512.new signature and must NOT be detected.
+h = SHA512.new(unknown_kwarg="value")

--- a/python/src/test/java/com/ibm/plugin/rules/detection/pycrypto/hash/PycryptoCryptoHashSHA512RequiredParamTest.java
+++ b/python/src/test/java/com/ibm/plugin/rules/detection/pycrypto/hash/PycryptoCryptoHashSHA512RequiredParamTest.java
@@ -1,0 +1,88 @@
+/*
+ * Sonar Cryptography Plugin
+ * Copyright (C) 2024 PQCA
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ibm.plugin.rules.detection.pycrypto.hash;
+
+import static com.ibm.engine.detection.MethodMatcher.ANY;
+
+import com.ibm.engine.detection.DetectionStore;
+import com.ibm.engine.model.context.DigestContext;
+import com.ibm.engine.model.factory.ValueActionFactory;
+import com.ibm.engine.rule.IDetectionRule;
+import com.ibm.engine.rule.builder.DetectionRuleBuilder;
+import com.ibm.mapper.model.INode;
+import com.ibm.plugin.TestBase;
+import java.util.List;
+import javax.annotation.Nonnull;
+import org.junit.jupiter.api.Test;
+import org.sonar.plugins.python.api.PythonCheck;
+import org.sonar.plugins.python.api.PythonVisitorContext;
+import org.sonar.plugins.python.api.symbols.Symbol;
+import org.sonar.plugins.python.api.tree.Tree;
+import org.sonar.python.checks.utils.PythonCheckVerifier;
+
+/**
+ * Verifies that a rule with a <em>required</em> named parameter does not fire when that parameter
+ * is absent from the call site.
+ *
+ * <p>The rule used here mirrors {@code PycryptoCryptoHash.SHA512_NEW} except that {@code truncate}
+ * is declared with {@code optional=false}. A call of {@code SHA512.new()} — which omits {@code
+ * truncate} — must therefore produce no detection.
+ */
+class PycryptoCryptoHashSHA512RequiredParamTest extends TestBase {
+
+    private static final String BASE_PATH = "src/test/files/rules/detection/pycrypto/hash/";
+
+    /** Rule variant: truncate is required (optional=false). */
+    private static final IDetectionRule<Tree> SHA512_NEW_TRUNCATE_REQUIRED =
+            new DetectionRuleBuilder<Tree>()
+                    .createDetectionRule()
+                    .forObjectTypes("Crypto.Hash.SHA512")
+                    .forMethods("new")
+                    .shouldBeDetectedAs(new ValueActionFactory<>("SHA512"))
+                    .withNamedMethodParameter("data", ANY, /* optional */ true)
+                    .withNamedMethodParameter("truncate", "str", /* optional */ false)
+                    .buildForContext(new DigestContext())
+                    .inBundle(() -> "PyCrypto")
+                    .withoutDependingDetectionRules();
+
+    public PycryptoCryptoHashSHA512RequiredParamTest() {
+        super(List.of(SHA512_NEW_TRUNCATE_REQUIRED));
+    }
+
+    /**
+     * SHA512.new() with a rule that declares {@code truncate} as required. The rule must NOT fire
+     * because the required argument is absent.
+     */
+    @Test
+    void testNegativeRequiredNamedParamAbsent() {
+        PythonCheckVerifier.verifyNoIssue(
+                BASE_PATH + "SHA512NewNegativeRequiredNamedParamAbsentTest.py", this);
+    }
+
+    @Override
+    public void asserts(
+            int findingId,
+            @Nonnull DetectionStore<PythonCheck, Tree, Symbol, PythonVisitorContext> detectionStore,
+            @Nonnull List<INode> nodes) {
+        // This method must not be called: verifyNoIssue guarantees zero findings.
+        throw new AssertionError(
+                "No finding expected, but asserts() was called for finding #" + findingId);
+    }
+}

--- a/python/src/test/java/com/ibm/plugin/rules/detection/pycrypto/hash/PycryptoCryptoHashSHA512Test.java
+++ b/python/src/test/java/com/ibm/plugin/rules/detection/pycrypto/hash/PycryptoCryptoHashSHA512Test.java
@@ -62,25 +62,19 @@ class PycryptoCryptoHashSHA512Test extends TestBase {
 
     private static final String BASE_PATH = "src/test/files/rules/detection/pycrypto/hash/";
 
+    /**
+     * Set by each test method before calling {@code verify()} to tell {@link #asserts} whether the
+     * current fixture is expected to produce a truncate child detection.
+     */
+    private boolean expectTruncateChild = false;
+
     public PycryptoCryptoHashSHA512Test() {
         super(PycryptoCryptoHash.rules());
     }
 
     // -------------------------------------------------------------------------
-    // Positive tests
+    // Positive tests — truncate child expected
     // -------------------------------------------------------------------------
-
-    /** SHA512.new() — no arguments; both optional params absent; rule must still fire. */
-    @Test
-    void testNoArgs() {
-        PythonCheckVerifier.verify(BASE_PATH + "SHA512NewNoArgsTest.py", this);
-    }
-
-    /** SHA512.new(data=b"msg") — data by keyword; truncate absent (optional). */
-    @Test
-    void testDataKeyword() {
-        PythonCheckVerifier.verify(BASE_PATH + "SHA512NewDataKeywordTest.py", this);
-    }
 
     /**
      * SHA512.new(truncate="256") — truncate by keyword, data absent; truncate child must be
@@ -88,6 +82,7 @@ class PycryptoCryptoHashSHA512Test extends TestBase {
      */
     @Test
     void testTruncateKeywordOnly() {
+        expectTruncateChild = true;
         PythonCheckVerifier.verify(BASE_PATH + "SHA512NewTruncateKeywordOnlyTest.py", this);
     }
 
@@ -97,6 +92,7 @@ class PycryptoCryptoHashSHA512Test extends TestBase {
      */
     @Test
     void testBothKeywordsCanonicalOrder() {
+        expectTruncateChild = true;
         PythonCheckVerifier.verify(BASE_PATH + "SHA512NewBothKeywordsCanonicalOrderTest.py", this);
     }
 
@@ -106,6 +102,7 @@ class PycryptoCryptoHashSHA512Test extends TestBase {
      */
     @Test
     void testBothKeywordsReordered() {
+        expectTruncateChild = true;
         PythonCheckVerifier.verify(BASE_PATH + "SHA512NewBothKeywordsReorderedTest.py", this);
     }
 
@@ -115,6 +112,7 @@ class PycryptoCryptoHashSHA512Test extends TestBase {
      */
     @Test
     void testBothPositional() {
+        expectTruncateChild = true;
         PythonCheckVerifier.verify(BASE_PATH + "SHA512NewBothPositionalTest.py", this);
     }
 
@@ -124,19 +122,40 @@ class PycryptoCryptoHashSHA512Test extends TestBase {
      */
     @Test
     void testMixedPositionalKeyword() {
+        expectTruncateChild = true;
         PythonCheckVerifier.verify(BASE_PATH + "SHA512NewMixedPositionalKeywordTest.py", this);
-    }
-
-    /** SHA512.new(b"msg") — data by positional fallback, truncate absent (optional). */
-    @Test
-    void testDataPositionalOnly() {
-        PythonCheckVerifier.verify(BASE_PATH + "SHA512NewDataPositionalOnlyTest.py", this);
     }
 
     /** Cryptodome.Hash.SHA512 — same rule, different import module name. */
     @Test
     void testCryptodome() {
+        expectTruncateChild = true;
         PythonCheckVerifier.verify(BASE_PATH + "SHA512NewCryptodomeTest.py", this);
+    }
+
+    // -------------------------------------------------------------------------
+    // Positive tests — truncate child must be ABSENT
+    // -------------------------------------------------------------------------
+
+    /** SHA512.new() — no arguments; both optional params absent; rule must still fire. */
+    @Test
+    void testNoArgs() {
+        expectTruncateChild = false;
+        PythonCheckVerifier.verify(BASE_PATH + "SHA512NewNoArgsTest.py", this);
+    }
+
+    /** SHA512.new(data=b"msg") — data by keyword; truncate absent (optional). */
+    @Test
+    void testDataKeyword() {
+        expectTruncateChild = false;
+        PythonCheckVerifier.verify(BASE_PATH + "SHA512NewDataKeywordTest.py", this);
+    }
+
+    /** SHA512.new(b"msg") — data by positional fallback, truncate absent (optional). */
+    @Test
+    void testDataPositionalOnly() {
+        expectTruncateChild = false;
+        PythonCheckVerifier.verify(BASE_PATH + "SHA512NewDataPositionalOnlyTest.py", this);
     }
 
     /**
@@ -146,6 +165,7 @@ class PycryptoCryptoHashSHA512Test extends TestBase {
      */
     @Test
     void testWrongTypeTruncateOptionalSkipped() {
+        expectTruncateChild = false;
         PythonCheckVerifier.verify(BASE_PATH + "SHA512NewNegativeWrongTypeTest.py", this);
     }
 
@@ -226,18 +246,26 @@ class PycryptoCryptoHashSHA512Test extends TestBase {
         assertThat(digestNode.asString()).isEqualTo("DIGEST");
 
         /*
-         * If a truncate child detection store is present, validate its value.
-         * Tests that pass truncate="256" produce one AlgorithmParameter child.
-         * Tests that do NOT pass truncate produce no AlgorithmParameter child.
+         * Assert the presence or absence of the truncate child detection store, depending on
+         * which call site the current test exercises. expectTruncateChild is set by each test
+         * method before calling verify() so this shared asserts() method can distinguish the
+         * two cases.
          */
         DetectionStore<PythonCheck, Tree, Symbol, PythonVisitorContext> truncateStore =
                 getStoreOfValueType(AlgorithmParameter.class, detectionStore.getChildren());
-        if (truncateStore != null) {
+        if (expectTruncateChild) {
+            assertThat(truncateStore)
+                    .as("expected a truncate child detection store but found none")
+                    .isNotNull();
             assertThat(truncateStore.getDetectionValues()).hasSize(1);
             assertThat(truncateStore.getDetectionValueContext()).isInstanceOf(DigestContext.class);
             IValue<Tree> truncateValue = truncateStore.getDetectionValues().get(0);
             assertThat(truncateValue).isInstanceOf(AlgorithmParameter.class);
             assertThat(truncateValue.asString()).isEqualTo("256");
+        } else {
+            assertThat(truncateStore)
+                    .as("expected no truncate child detection store but one was produced")
+                    .isNull();
         }
     }
 }

--- a/python/src/test/java/com/ibm/plugin/rules/detection/pycrypto/hash/PycryptoCryptoHashSHA512Test.java
+++ b/python/src/test/java/com/ibm/plugin/rules/detection/pycrypto/hash/PycryptoCryptoHashSHA512Test.java
@@ -1,0 +1,243 @@
+/*
+ * Sonar Cryptography Plugin
+ * Copyright (C) 2024 PQCA
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ibm.plugin.rules.detection.pycrypto.hash;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.ibm.engine.detection.DetectionStore;
+import com.ibm.engine.model.AlgorithmParameter;
+import com.ibm.engine.model.IValue;
+import com.ibm.engine.model.ValueAction;
+import com.ibm.engine.model.context.DigestContext;
+import com.ibm.mapper.model.INode;
+import com.ibm.mapper.model.MessageDigest;
+import com.ibm.mapper.model.functionality.Digest;
+import com.ibm.plugin.TestBase;
+import java.util.List;
+import javax.annotation.Nonnull;
+import org.junit.jupiter.api.Test;
+import org.sonar.plugins.python.api.PythonCheck;
+import org.sonar.plugins.python.api.PythonVisitorContext;
+import org.sonar.plugins.python.api.symbols.Symbol;
+import org.sonar.plugins.python.api.tree.Tree;
+import org.sonar.python.checks.utils.PythonCheckVerifier;
+
+/**
+ * Extensive positive and negative tests for the {@code SHA512.new} detection rule, verifying the
+ * {@code withNamedMethodParameter} feature:
+ *
+ * <ul>
+ *   <li>Both parameters absent (no-args call) → match, no truncate child
+ *   <li>Only {@code data} by keyword → match, no truncate child
+ *   <li>Only {@code truncate} by keyword → match, truncate child captured
+ *   <li>Both by keyword, canonical order → match, truncate child captured
+ *   <li>Both by keyword, reordered → match, truncate child captured
+ *   <li>Both positional → match, truncate child captured
+ *   <li>Mixed positional/keyword → match, truncate child captured
+ *   <li>Only data positional → match, no truncate child
+ *   <li>Cryptodome module variant → match, truncate child captured
+ *   <li>Different algorithm (SHA256) → no match
+ *   <li>Wrong method name → no match
+ *   <li>Unknown keyword only → match (both optional params absent), no truncate child
+ * </ul>
+ */
+class PycryptoCryptoHashSHA512Test extends TestBase {
+
+    private static final String BASE_PATH = "src/test/files/rules/detection/pycrypto/hash/";
+
+    public PycryptoCryptoHashSHA512Test() {
+        super(PycryptoCryptoHash.rules());
+    }
+
+    // -------------------------------------------------------------------------
+    // Positive tests
+    // -------------------------------------------------------------------------
+
+    /** SHA512.new() — no arguments; both optional params absent; rule must still fire. */
+    @Test
+    void testNoArgs() {
+        PythonCheckVerifier.verify(BASE_PATH + "SHA512NewNoArgsTest.py", this);
+    }
+
+    /** SHA512.new(data=b"msg") — data by keyword; truncate absent (optional). */
+    @Test
+    void testDataKeyword() {
+        PythonCheckVerifier.verify(BASE_PATH + "SHA512NewDataKeywordTest.py", this);
+    }
+
+    /**
+     * SHA512.new(truncate="256") — truncate by keyword, data absent; truncate child must be
+     * captured.
+     */
+    @Test
+    void testTruncateKeywordOnly() {
+        PythonCheckVerifier.verify(BASE_PATH + "SHA512NewTruncateKeywordOnlyTest.py", this);
+    }
+
+    /**
+     * SHA512.new(data=b"msg", truncate="256") — both by keyword name, canonical order; truncate
+     * child must be captured.
+     */
+    @Test
+    void testBothKeywordsCanonicalOrder() {
+        PythonCheckVerifier.verify(BASE_PATH + "SHA512NewBothKeywordsCanonicalOrderTest.py", this);
+    }
+
+    /**
+     * SHA512.new(truncate="256", data=b"msg") — both by keyword name, reordered; engine must find
+     * each parameter by name, not by position.
+     */
+    @Test
+    void testBothKeywordsReordered() {
+        PythonCheckVerifier.verify(BASE_PATH + "SHA512NewBothKeywordsReorderedTest.py", this);
+    }
+
+    /**
+     * SHA512.new(b"msg", "256") — both positional; engine uses positional fallback (data→0,
+     * truncate→1).
+     */
+    @Test
+    void testBothPositional() {
+        PythonCheckVerifier.verify(BASE_PATH + "SHA512NewBothPositionalTest.py", this);
+    }
+
+    /**
+     * SHA512.new(b"msg", truncate="256") — data by positional fallback (index 0), truncate by
+     * keyword name.
+     */
+    @Test
+    void testMixedPositionalKeyword() {
+        PythonCheckVerifier.verify(BASE_PATH + "SHA512NewMixedPositionalKeywordTest.py", this);
+    }
+
+    /** SHA512.new(b"msg") — data by positional fallback, truncate absent (optional). */
+    @Test
+    void testDataPositionalOnly() {
+        PythonCheckVerifier.verify(BASE_PATH + "SHA512NewDataPositionalOnlyTest.py", this);
+    }
+
+    /** Cryptodome.Hash.SHA512 — same rule, different import module name. */
+    @Test
+    void testCryptodome() {
+        PythonCheckVerifier.verify(BASE_PATH + "SHA512NewCryptodomeTest.py", this);
+    }
+
+    /**
+     * SHA512.new(truncate=256) — {@code truncate} declared as {@code "str"} but an int literal is
+     * passed. The type check rejects the truncate argument; because it is optional the param is
+     * treated as absent. SHA-512 is still detected, but without a truncate child.
+     */
+    @Test
+    void testWrongTypeTruncateOptionalSkipped() {
+        PythonCheckVerifier.verify(BASE_PATH + "SHA512NewNegativeWrongTypeTest.py", this);
+    }
+
+    // -------------------------------------------------------------------------
+    // Negative tests
+    // -------------------------------------------------------------------------
+
+    /** SHA256.new() — different algorithm; SHA512 rule must NOT match. */
+    @Test
+    void testNegativeDifferentAlgo() {
+        PythonCheckVerifier.verifyNoIssue(
+                BASE_PATH + "SHA512NewNegativeDifferentAlgoTest.py", this);
+    }
+
+    /** SHA512.update() — wrong method name; rule must NOT match. */
+    @Test
+    void testNegativeWrongMethod() {
+        PythonCheckVerifier.verifyNoIssue(BASE_PATH + "SHA512NewNegativeWrongMethodTest.py", this);
+    }
+
+    /**
+     * SHA512.new(unknown_kwarg="value") — keyword argument not declared in the rule; the engine
+     * must reject the call because the signature does not match.
+     */
+    @Test
+    void testNegativeUnknownKwarg() {
+        PythonCheckVerifier.verifyNoIssue(BASE_PATH + "SHA512NewUnknownKwargTest.py", this);
+    }
+
+    /**
+     * SHA512.new(**d) — dict-unpacking argument; contents are not statically inspectable; must NOT
+     * be detected.
+     */
+    @Test
+    void testNegativeDictUnpack() {
+        PythonCheckVerifier.verifyNoIssue(BASE_PATH + "SHA512NewNegativeDictUnpackTest.py", this);
+    }
+
+    /**
+     * SHA512.new(*args) — sequence-unpacking argument; contents are not statically inspectable;
+     * must NOT be detected.
+     */
+    @Test
+    void testNegativeSeqUnpack() {
+        PythonCheckVerifier.verifyNoIssue(BASE_PATH + "SHA512NewNegativeSeqUnpackTest.py", this);
+    }
+
+    // -------------------------------------------------------------------------
+    // asserts — called once per finding
+    // -------------------------------------------------------------------------
+
+    @Override
+    public void asserts(
+            int findingId,
+            @Nonnull DetectionStore<PythonCheck, Tree, Symbol, PythonVisitorContext> detectionStore,
+            @Nonnull List<INode> nodes) {
+
+        /*
+         * Every positive test produces exactly one top-level detection for SHA512.
+         */
+        assertThat(detectionStore.getDetectionValues()).hasSize(1);
+        assertThat(detectionStore.getDetectionValueContext()).isInstanceOf(DigestContext.class);
+
+        IValue<Tree> rootValue = detectionStore.getDetectionValues().get(0);
+        assertThat(rootValue).isInstanceOf(ValueAction.class);
+        assertThat(rootValue.asString()).isEqualTo("SHA512");
+
+        /*
+         * Translation: the root node must be a MessageDigest for SHA-512, with a Digest child.
+         */
+        assertThat(nodes).hasSize(1);
+        INode messageDigestNode = nodes.get(0);
+        assertThat(messageDigestNode.getKind()).isEqualTo(MessageDigest.class);
+        assertThat(messageDigestNode.asString()).isEqualTo("SHA-512");
+
+        INode digestNode = messageDigestNode.getChildren().get(Digest.class);
+        assertThat(digestNode).isNotNull();
+        assertThat(digestNode.asString()).isEqualTo("DIGEST");
+
+        /*
+         * If a truncate child detection store is present, validate its value.
+         * Tests that pass truncate="256" produce one AlgorithmParameter child.
+         * Tests that do NOT pass truncate produce no AlgorithmParameter child.
+         */
+        DetectionStore<PythonCheck, Tree, Symbol, PythonVisitorContext> truncateStore =
+                getStoreOfValueType(AlgorithmParameter.class, detectionStore.getChildren());
+        if (truncateStore != null) {
+            assertThat(truncateStore.getDetectionValues()).hasSize(1);
+            assertThat(truncateStore.getDetectionValueContext()).isInstanceOf(DigestContext.class);
+            IValue<Tree> truncateValue = truncateStore.getDetectionValues().get(0);
+            assertThat(truncateValue).isInstanceOf(AlgorithmParameter.class);
+            assertThat(truncateValue.asString()).isEqualTo("256");
+        }
+    }
+}


### PR DESCRIPTION
# Add `withNamedMethodParameter` to the detection rule DSL

**Engine · Python · keyword-argument-aware parameter matching**

## Motivation

Python callers routinely pass arguments out of order using keyword syntax, and routinely omit optional parameters entirely:

```python
SHA512.new(truncate="256")                                       # data omitted
SHA512.new(truncate="256", data=b"msg")                          # reordered
PBKDF2HMAC(iterations=480000, algorithm=SHA256(), salt=s, length=32)  # fully reordered
```

The existing `withMethodParameter(type)` method is purely positional: it reads argument *n* for parameter *n* and requires an exact argument count enforced by `MethodMatcher`. It cannot handle reordered arguments, omitted optional parameters, or the keyword-argument call style that is idiomatic in Python cryptography APIs. `withNamedMethodParameter` solves all three.

## New DSL method

```java
ParametersFactoryBuilder<T> withNamedMethodParameter(
    @Nonnull String  name,      // Python keyword-argument name
    @Nonnull String  type,      // accepted type; use ANY for no constraint
             boolean optional   // true → absent or type-mismatched argument is silently skipped
);
```

### Ordering constraint

`withMethodParameter` declarations must precede all `withNamedMethodParameter` declarations in a rule. Violation throws `IllegalStateException` at rule construction time.

### MethodMatcher mode selection

When all parameters are declared with `withMethodParameter` the existing exact-count type-list `MethodMatcher` is used — no change in behaviour. As soon as at least one `withNamedMethodParameter` is declared the no-type-list constructor is used instead, which accepts any call to the matched method and delegates all structural checking to the extraction loop described below.

## Extraction algorithm

For each `withNamedMethodParameter` declaration, in declaration order:

1. **Keyword-name lookup** — scan the call-site argument list for a `RegularArgument` whose `keywordArgument().name()` equals `name`. If found, use that argument regardless of its position.
2. **Positional fallback** — if step 1 finds nothing, check the argument at the parameter's declaration index. Accept it only if that argument is itself positional (no keyword marker). If a preceding `optional=true` parameter was skipped, emit a `WARN` log before accepting (positional attribution may be ambiguous).
3. **Type check** — once an argument is resolved, verify its static type against the declared `type`. Skipped when `type` is `ANY`. When the type cannot be statically determined, `resolveTreeType` returns an accept-all predicate — the same conservative fallback used by `MethodMatcher` for positional parameters. On mismatch: `optional=true` → treat as absent and skip; `optional=false` → rule does not fire.
4. **Not found** — `optional=false`: rule does not fire. `optional=true`: skip silently.

## Pre-extraction guards (all run before any finding is emitted)

The following checks apply only when at least one named parameter is declared. All run before `MethodDetection` is emitted, so a rejected call produces no finding at all.

- **Unpacking guard** — if any call-site argument is an `UnpackingExpression` (`**d` or `*args`), the call is rejected. The contents of unpacked iterables and dicts cannot be statically inspected, so no structural guarantee can be made.
- **Unknown-keyword guard** — if any call-site keyword argument has a name that is not declared in any `withNamedMethodParameter` in the rule, the call is rejected. The call does not match the function signature the rule was written for.

## Example — `SHA512.new(data=None, truncate=None)`

```java
new DetectionRuleBuilder<Tree>()
    .createDetectionRule()
    .forObjectTypes("Crypto.Hash.SHA512", "Cryptodome.Hash.SHA512")
    .forMethods("new")
    .shouldBeDetectedAs(new ValueActionFactory<>("SHA512"))
    .withNamedMethodParameter("data",     ANY,   /*optional*/ true)
    .withNamedMethodParameter("truncate", "str", /*optional*/ true)
        .shouldBeDetectedAs(new AlgorithmParameterFactory<>(AlgorithmParameter.Kind.ANY))
        .asChildOfParameterWithId(0)
    .buildForContext(new DigestContext())
    .inBundle(() -> "PyCrypto")
    .withoutDependingDetectionRules();
```

| Call site | Matches? | `truncate` captured? | Reason |
|-----------|:--------:|:--------------------:|--------|
| `SHA512.new()` | ✓ | — | Both absent, both optional |
| `SHA512.new(data=b"msg")` | ✓ | — | data by keyword; truncate absent → skipped |
| `SHA512.new(truncate="256")` | ✓ | ✓ | truncate by keyword; data absent → skipped |
| `SHA512.new(data=b"msg", truncate="256")` | ✓ | ✓ | Both by keyword, canonical order |
| `SHA512.new(truncate="256", data=b"msg")` | ✓ | ✓ | Both by keyword, reordered |
| `SHA512.new(b"msg", "256")` | ✓ | ✓ | Both by positional fallback |
| `SHA512.new(b"msg", truncate="256")` | ✓ | ✓ | data positional fallback; truncate by keyword |
| `SHA512.new(truncate=256)` | ✓ | — | int literal fails "str" type check; optional → skipped |
| `SHA512.new(unknown_kwarg="x")` | ✗ | — | Unknown keyword guard |
| `SHA512.new(**d)` | ✗ | — | Unpacking guard |
| `SHA512.new(*args)` | ✗ | — | Unpacking guard |

## Changed files

| File | Change |
|------|--------|
| `engine/…/rule/Parameter.java` | Added `keywordName` and `keywordOptional` fields, two new constructors, and `getKeywordName()` / `isKeywordOptional()` accessors. |
| `engine/…/rule/DetectableParameter.java` | New constructor threading both new fields through `super()`. |
| `engine/…/rule/IDetectionRule.java` | Added `withNamedMethodParameter(name, type, optional)` to all six builder step interfaces. |
| `engine/…/rule/builder/DetectionRuleBuilderImpl.java` | Implemented the new method; enforces ordering constraint; updates `build()` to select the no-type-list `MethodMatcher` when named params are present. Introduced a `copy()` helper to eliminate repeated constructor calls. |
| `engine/…/language/python/PythonDetectionEngine.java` | Updated `analyseExpression()`: unpacking guard; unknown-keyword guard; `MethodDetection` emission moved after both guards; keyword-name lookup with positional fallback and Hole 1 `WARN` log; per-argument type check using `PythonSemantic.resolveTreeType`. Added `findArgumentByKeyword()` helper and extracted shared loop body into `processParameterExpression()`. Updated `getTraceSymbol()` to apply the same keyword-name lookup. |
| `python/…/detection/pycrypto/hash/PycryptoCryptoHash.java` | New example rule for `Crypto.Hash.SHA512.new` / `Cryptodome.Hash.SHA512.new` demonstrating the feature. |
| `python/…/detection/pycrypto/hash/PycryptoCryptoHashSHA512Test.java` + 15 Python fixture files | 15 test cases covering all positive call-site variants, type-mismatch skipping, unknown-keyword rejection, unpacking rejection, wrong-algorithm and wrong-method negative cases. |

## Known limitation

There is no upper-bound arity check: extra positional arguments beyond the declared parameter count are silently ignored. This does not occur in valid Python (the interpreter would raise `TypeError`), so it is not a source of false positives in practice. The unpacking guard already handles the one realistic case where extra arguments could arrive opaquely (`**d`).
