### PR TITLE
ci: submit the real Maven dependency graph to GitHub

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -42,7 +42,9 @@ jobs:
         name: "CBOM"
         path: ${{ steps.cbom.outputs.pattern }}
         if-no-files-found: warn
-    # Optional: Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive
-    #- name: Update dependency graph
-    #  uses: advanced-security/maven-dependency-submission-action@v5
-    #  if: github.event_name != 'pull_request'
+    # Uploads the full, resolved dependency graph to GitHub. Without this,
+    # GitHub guesses the graph by parsing the pom.xml files and reports
+    # Dependabot alerts for versions we do not actually build with.
+    - name: Update dependency graph
+      uses: advanced-security/maven-dependency-submission-action@v5
+      if: github.event_name != 'pull_request'


### PR DESCRIPTION
## Problem

The repo has 167 open Dependabot alerts. All of them are false positives.

GitHub builds the dependency graph by parsing the `pom.xml` files itself, and its copy is stale. It lists `sonar-java-plugin` 8.18.0 and `sonar-python-plugin` 5.16.0 while `main` uses 8.22.0 and 5.29.0. It also has no entry for the `csharp` module added in #496. So it carries the old transitive Jackson and Spring versions.

The versions we actually resolve (checked with `mvn dependency:tree`) are all past the patched version:

| Package | Vulnerable range (worst alert) | We build with | Affected? |
|---|---|---|---|
| jackson-databind | `>= 2.19.0, < 2.21.5` | 2.22.1 | no |
| jackson-core | `>= 2.19.0, < 2.21.4` | 2.22.1 | no |
| spring-core / spring-expression | `>= 6.0.0, <= 6.1.22` | 6.2.11 | no |
| logback-core | `< 1.5.34` | 1.5.35 (pinned) | no |
| assertj-core | `<= 3.27.6` | 3.27.7 | no |
| bcprov-jdk18on | `>= 1.82, < 1.84` | 1.84 | no |

The alerts are duplicated 11 times each because the root pom declares the shared dependencies in `<dependencies>`. Every module inherits the same tree, and GitHub counts each module pom as its own manifest. 18 advisories x 11 manifests = ~167 alerts.

## Change

Enables the dependency submission step that was already in `maven.yml` but commented out. It uploads the resolved dependency tree after each build on `main`, so GitHub stops guessing and Dependabot closes the stale alerts.

The action also marks test-scope dependencies as `development`, which drops logback, assertj and bouncycastle out of the runtime alert count.

## Notes

- The workflow already has `permissions: contents: write`, which the action needs.
- The step is skipped on pull requests, so it only runs after a merge to `main`.
- Alerts should clear on their own after the first run. If some stay, they can be dismissed as `inaccurate`.