### PR TITLE
fix: stop the build from rewriting the cipher-suite source files

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -31,6 +31,16 @@ jobs:
         cache: maven
     - name: Build with Maven
       run: mvn -B clean package
+    # The build must not write into the source tree. It used to: the mapper
+    # module regenerated ciphersuites.json and JsonCipherSuites.java from a live
+    # API on every compile. Fail here if that ever comes back.
+    - name: Check the build left the working tree clean
+      run: |
+        if ! git diff --quiet; then
+          echo "The build modified tracked files:"
+          git diff --stat
+          exit 1
+        fi
     - name: Create CBOM
       uses: cbomkit/cbomkit-action@v2.2.0
       id: cbom

--- a/.github/workflows/update-cipher-suites.yml
+++ b/.github/workflows/update-cipher-suites.yml
@@ -1,0 +1,76 @@
+# Refreshes the cipher-suite data in the mapper module.
+#
+# This used to run on every build, bound to the Maven compile phase. That
+# overwrote mapper/ciphersuites.json and JsonCipherSuites.java in the source
+# tree from a live API, so every build left the working tree dirty and the
+# shipped data depended on the build date.
+#
+# Now the refresh runs on a schedule and opens a pull request instead, so any
+# change to the cipher-suite list is reviewed before it lands.
+
+name: Update cipher suites
+
+on:
+  schedule:
+    # First day of each month, 04:00 UTC.
+    - cron: '0 4 1 * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: maven
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.x'
+
+      - name: Download cipher suites and regenerate the Java file
+        run: ./download-cipher-suites.sh
+        working-directory: mapper
+
+      - name: Format the generated file
+        run: mvn -B -pl mapper spotless:apply
+
+      - name: Open a pull request
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if git diff --quiet; then
+            echo "Cipher-suite data is unchanged. Nothing to do."
+            exit 0
+          fi
+
+          branch="chore/update-cipher-suites-${GITHUB_RUN_ID}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$branch"
+          git add mapper/ciphersuites.json \
+                  mapper/src/main/java/com/ibm/mapper/mapper/ssl/json/JsonCipherSuites.java
+          git commit -m "chore: update cipher-suite data from ciphersuite.info"
+          git push origin "$branch"
+
+          # Note: a pull request opened with GITHUB_TOKEN does not start other
+          # workflows, so CI will not run on it on its own. Close and reopen the
+          # pull request to start CI, or swap in a personal access token.
+          gh pr create \
+            --base main \
+            --head "$branch" \
+            --title "chore: update cipher-suite data from ciphersuite.info" \
+            --body "Automated refresh of \`mapper/ciphersuites.json\` and the generated \`JsonCipherSuites.java\`.
+
+          Source: https://ciphersuite.info/api/cs/
+
+          Check the diff before merging. A large drop in the number of entries means something is wrong upstream."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,12 @@ mvn spotless:check
 mvn checkstyle:check
 ```
 
+**Cipher-suite data:** `mapper/ciphersuites.json` and the generated
+`mapper/src/main/java/.../ssl/json/JsonCipherSuites.java` are checked into git. The build does
+not touch them. To refresh them from ciphersuite.info, run `mapper/download-cipher-suites.sh`
+and then `mvn -pl mapper spotless:apply`, or trigger the `Update cipher suites` workflow, which
+opens a pull request with the change.
+
 ## Testing
 
 ```bash

--- a/docs/PERFORMANCE_TESTING.md
+++ b/docs/PERFORMANCE_TESTING.md
@@ -118,10 +118,6 @@ mvn clean package -DskipTests
 ls -la sonar-cryptography-plugin/target/sonar-cryptography-plugin-*.jar   # the artifact
 ```
 
-> The build no longer writes into the source tree, so `git status` stays clean after it.
-> It used to regenerate `mapper/ciphersuites.json` and `mapper/.../JsonCipherSuites.java` from a
-> live API on every compile. If you see those files change again, something reintroduced that.
-
 **3b. Deploy the JAR into the compose-mounted plugins directory:**
 
 ```bash

--- a/docs/PERFORMANCE_TESTING.md
+++ b/docs/PERFORMANCE_TESTING.md
@@ -118,8 +118,9 @@ mvn clean package -DskipTests
 ls -la sonar-cryptography-plugin/target/sonar-cryptography-plugin-*.jar   # the artifact
 ```
 
-> If `mvn` reformats/regenerates `mapper/.../JsonCipherSuites.java` (a known Spotless/fetch
-> quirk), restore it before committing: `git checkout -- mapper/src/main/java/com/ibm/mapper/mapper/ssl/json/JsonCipherSuites.java`.
+> The build no longer writes into the source tree, so `git status` stays clean after it.
+> It used to regenerate `mapper/ciphersuites.json` and `mapper/.../JsonCipherSuites.java` from a
+> live API on every compile. If you see those files change again, something reintroduced that.
 
 **3b. Deploy the JAR into the compose-mounted plugins directory:**
 

--- a/mapper/download-cipher-suites.sh
+++ b/mapper/download-cipher-suites.sh
@@ -1,12 +1,49 @@
 #!/bin/sh
+#
+# Refreshes the cipher-suite data used by the mapper module.
+#
+# It downloads ciphersuites.json from ciphersuite.info and regenerates
+# src/main/java/com/ibm/mapper/mapper/ssl/json/JsonCipherSuites.java from it.
+#
+# This is NOT part of the Maven build. Run it by hand when you want to pick up
+# new cipher suites, or let the update-cipher-suites workflow run it for you.
+# Both files are checked into git, so the change shows up as a reviewable diff.
+#
+# After running this, format the generated Java file:
+#     mvn -pl mapper spotless:apply
+# The generator writes one entry per line and no license header. Spotless adds
+# the header and the normal formatting.
+
+set -eu
 
 url=https://ciphersuite.info/api/cs/
-status_code=$(curl -s -o /dev/null -w "%{http_code}" "$url")
+target=ciphersuites.json
+tmp=$(mktemp)
+# Do not leave the temp file behind if we exit early.
+trap 'rm -f "$tmp"' EXIT
 
-if [ "$status_code" -eq 200 ]; then
-    curl "$url" -o ciphersuites.json
-    echo "Successfully processed $url"
-    python3 creatCipherSuiteClass.py
-else
-    echo "Failed to process $url (Status code: $status_code)"
+# --fail makes curl exit non-zero on a 4xx/5xx instead of writing the error
+# page to disk. We download to a temp file so a bad response can never
+# overwrite the good data we already have.
+if ! curl --fail --silent --show-error --location --max-time 60 "$url" -o "$tmp"; then
+    echo "Failed to download $url - keeping the current $target" >&2
+    exit 1
 fi
+
+# The API has to give us parseable JSON with a plausible number of entries.
+# A sharp drop means the API changed or returned a partial body, and we would
+# rather stop than commit a shrunken cipher-suite list.
+new_count=$(python3 -c 'import json,sys; print(len(json.load(open(sys.argv[1]))["ciphersuites"]))' "$tmp")
+old_count=$(python3 -c 'import json,sys; print(len(json.load(open(sys.argv[1]))["ciphersuites"]))' "$target")
+
+if [ "$new_count" -lt $(( old_count * 9 / 10 )) ]; then
+    echo "Refusing to update: $url returned $new_count entries, down from $old_count." >&2
+    echo "If this drop is real, update $target by hand." >&2
+    exit 1
+fi
+
+mv "$tmp" "$target"
+echo "Updated $target: $old_count -> $new_count cipher suites"
+
+python3 creatCipherSuiteClass.py
+echo "Regenerated JsonCipherSuites.java - now run: mvn -pl mapper spotless:apply"

--- a/mapper/pom.xml
+++ b/mapper/pom.xml
@@ -24,26 +24,17 @@
         </dependency>
     </dependencies>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>exec-maven-plugin</artifactId>
-                <version>3.6.3</version>
-                <executions>
-                    <execution>
-                        <phase>compile</phase>
-                        <goals>
-                            <goal>exec</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <executable>${basedir}/download-cipher-suites.sh</executable>
-                    <workingDirectory>${basedir}</workingDirectory>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
+    <!--
+        ciphersuites.json and src/main/java/.../ssl/json/JsonCipherSuites.java are
+        generated files that we keep in git on purpose.
+
+        They used to be regenerated on every build by download-cipher-suites.sh,
+        bound to the compile phase. That overwrote both files in the source tree
+        from a live third-party API, so every build left the working tree dirty
+        and the shipped cipher-suite data depended on the build date.
+
+        To refresh them, run mapper/download-cipher-suites.sh by hand, or let the
+        update-cipher-suites workflow do it and open a pull request.
+    -->
 
 </project>

--- a/mapper/pom.xml
+++ b/mapper/pom.xml
@@ -24,17 +24,4 @@
         </dependency>
     </dependencies>
 
-    <!--
-        ciphersuites.json and src/main/java/.../ssl/json/JsonCipherSuites.java are
-        generated files that we keep in git on purpose.
-
-        They used to be regenerated on every build by download-cipher-suites.sh,
-        bound to the compile phase. That overwrote both files in the source tree
-        from a live third-party API, so every build left the working tree dirty
-        and the shipped cipher-suite data depended on the build date.
-
-        To refresh them, run mapper/download-cipher-suites.sh by hand, or let the
-        update-cipher-suites workflow do it and open a pull request.
-    -->
-
 </project>


### PR DESCRIPTION
## The bug

Every `mvn compile` leaves two files modified in the working tree:

```
 M mapper/ciphersuites.json
 M mapper/src/main/java/com/ibm/mapper/mapper/ssl/json/JsonCipherSuites.java
```

`mapper/pom.xml` bound `exec-maven-plugin` to the **compile** phase to run `download-cipher-suites.sh`. That script downloads `https://ciphersuite.info/api/cs/` over the checked-in `ciphersuites.json`, then runs `creatCipherSuiteClass.py`, which overwrites `JsonCipherSuites.java` **in the source tree**.

## It was never Spotless, and nothing was truncated

This has been recorded as "Spotless intermittently truncates JsonCipherSuites.java". That is not what happens.

The generator writes one `Map.entry(...)` per line and no license header. That gives a 363-line file with all 348 entries present. Spotless runs later, at the `package` phase, and expands it back to 3861 lines with the header.

So:

| You run | What you are left with |
|---|---|
| `mvn compile` | 363 lines, no license header |
| `mvn package` | 3861 lines, header restored by Spotless |

Stopping at `compile`, or skipping Spotless, leaves the short version. It looks truncated, but no data was lost.

Reproduced on a clean tree at `main`:

```
$ mvn -q clean compile -pl mapper -am -DskipTests
$ git status --short
 M mapper/ciphersuites.json
 M mapper/src/main/java/com/ibm/mapper/mapper/ssl/json/JsonCipherSuites.java
$ wc -l mapper/src/main/java/.../JsonCipherSuites.java
366
```

The second half of the problem is drift. The API returns **351** entries today; the repo has **348**. So even a full `mvn package` leaves the tree dirty, and the cipher-suite data shipped in the plugin depends on the day it was built.

## Changes

**1. Take the generator out of the build** — `mapper/pom.xml`

Removed the `exec-maven-plugin` block. `ciphersuites.json` and `JsonCipherSuites.java` stay in git as vendored generated files, and the build just compiles them. Builds are now reproducible and work offline.

**2. Refresh on a schedule instead** — `.github/workflows/update-cipher-suites.yml` (new)

Runs monthly (and on demand). It runs the script, formats with Spotless, and opens a pull request. Data changes get reviewed instead of appearing silently in someone's working tree.

**3. Harden the script** — `mapper/download-cipher-suites.sh`

- `set -eu`
- `curl --fail` so a 4xx/5xx does not get written to disk as if it were data
- download to a temp file, move into place only after the JSON parses
- refuse to write if the entry count drops more than 10%

Both failure paths tested:

```
$ ./download-cipher-suites.sh          # 404 endpoint
Failed to download ... - keeping the current ciphersuites.json
exit=1, ciphersuites.json untouched

$ ./download-cipher-suites.sh          # server returns 10 entries
Refusing to update: ... returned 10 entries, down from 351.
exit=1, ciphersuites.json untouched
```

**4. CI guard** — `.github/workflows/maven.yml`

Fails the build if `mvn clean package` modified any tracked file. This stops the problem from coming back.

**5. Docs** — `docs/PERFORMANCE_TESTING.md` carried the wrong explanation; `CLAUDE.md` now says how to refresh the data.

## Verification

```
mvn -B clean package     -> BUILD SUCCESS, all 12 modules
                            413 tests, 0 failures
git diff after build     -> clean (new CI guard passes)
JsonCipherSuites.java    -> stays at 3861 lines
```

## Note

A pull request opened with `GITHUB_TOKEN` does not start other workflows, so CI will not run on the automated refresh PRs on its own. Close and reopen one to start CI, or swap in a PAT. There is a comment in the workflow saying so.