### PR TITLE
ci: run the dependency graph submission before the CBOM step

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -41,6 +41,15 @@ jobs:
           git diff --stat
           exit 1
         fi
+    # Uploads the full, resolved dependency graph to GitHub. Without this,
+    # GitHub guesses the graph by parsing the pom.xml files and reports
+    # Dependabot alerts for versions we do not actually build with.
+    # This has to run before the CBOM step. That step is a Docker action and
+    # runs as root, so it leaves root-owned temp folders in the workspace. This
+    # action walks the whole workspace and would then stop with EACCES.
+    - name: Update dependency graph
+      uses: advanced-security/maven-dependency-submission-action@v5
+      if: github.event_name != 'pull_request'
     - name: Create CBOM
       uses: cbomkit/cbomkit-action@v2.2.0
       id: cbom
@@ -52,9 +61,3 @@ jobs:
         name: "CBOM"
         path: ${{ steps.cbom.outputs.pattern }}
         if-no-files-found: warn
-    # Uploads the full, resolved dependency graph to GitHub. Without this,
-    # GitHub guesses the graph by parsing the pom.xml files and reports
-    # Dependabot alerts for versions we do not actually build with.
-    - name: Update dependency graph
-      uses: advanced-security/maven-dependency-submission-action@v5
-      if: github.event_name != 'pull_request'


### PR DESCRIPTION
## What

Moves the `Update dependency graph` step so it runs right after the build and the clean-tree check, before the `Create CBOM` step.

## Why

The step was skipped on pull requests, so #515 went green and then the first run on `main` failed:

```
Error: EACCES: permission denied, scandir
'/home/runner/work/sonar-cryptography/sonar-cryptography/76d3.../1508...'
```

The `Create CBOM` step is a Docker action. It runs as root with the workspace mounted at `/github/workspace`, and the Sonar Java analyzer inside it leaves temp folders in the workspace. Those folders belong to root, so the runner user cannot read them.

The dependency submission action walks the whole workspace to collect its depgraph files. It reached one of those root-owned folders and stopped with `EACCES`.

## The fix

Run it before the CBOM step, while the workspace is still clean. Nothing else depends on the order:

- it still runs after the check that the build left the working tree clean,
- it only writes `maven-dependency-submission-action-depgraph.json` into `target/`, which is ignored,
- the CBOM step does not use the dependency graph.

## Testing

The step stays skipped on pull requests (it needs the `main` branch to submit a snapshot), so CI here cannot prove it. The next push to `main` is the real test.