### PR TITLE
chore(deps): manage sonar-analyzer-test-commons in the parent pom

### DIFF
--- a/csharp/pom.xml
+++ b/csharp/pom.xml
@@ -39,13 +39,6 @@
       <version>2.0.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
-    <!-- Test dependencies -->
-    <dependency>
-      <groupId>org.sonarsource.analyzer-commons</groupId>
-      <artifactId>sonar-analyzer-test-commons</artifactId>
-      <version>2.18.0.3393</version>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
 </project>

--- a/go/pom.xml
+++ b/go/pom.xml
@@ -42,7 +42,6 @@
       <dependency>
           <groupId>org.sonarsource.analyzer-commons</groupId>
           <artifactId>sonar-analyzer-test-commons</artifactId>
-          <version>2.18.0.3393</version>
           <scope>test</scope>
       </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,7 @@
         <sonar.java.version>8.22.0.41895</sonar.java.version>
         <sonar.python.version>5.29.0.35837</sonar.python.version>
         <sonar.go.version>1.32.0.5128</sonar.go.version>
+        <sonar.analyzer-commons.version>2.30.0.5193</sonar.analyzer-commons.version>
 
         <google-java-format.version>1.28.0</google-java-format.version>
     </properties>
@@ -91,6 +92,12 @@
           <groupId>org.slf4j</groupId>
           <artifactId>slf4j-api</artifactId>
           <version>2.0.18</version>
+        </dependency>
+        <dependency>
+          <groupId>org.sonarsource.analyzer-commons</groupId>
+          <artifactId>sonar-analyzer-test-commons</artifactId>
+          <version>${sonar.analyzer-commons.version}</version>
+          <scope>test</scope>
         </dependency>
       </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
## Why

`org.sonarsource.analyzer-commons:sonar-analyzer-test-commons` had its version hardcoded in two module poms (`go` and `csharp`), both at `2.18.0.3393`. There was no design reason for this — it grew by copy‑paste. The `go` module added it with Go support (#361), and `csharp` copied the block when it was added (#496).

The result: Dependabot has to patch two files for every bump. See #513.

## What changed

**Parent `pom.xml`** — new property and a `dependencyManagement` entry, bumped to `2.30.0.5193` (the version #513 proposes):

```xml
<sonar.analyzer-commons.version>2.30.0.5193</sonar.analyzer-commons.version>
```

```xml
<dependency>
  <groupId>org.sonarsource.analyzer-commons</groupId>
  <artifactId>sonar-analyzer-test-commons</artifactId>
  <version>${sonar.analyzer-commons.version}</version>
  <scope>test</scope>
</dependency>
```

**`go/pom.xml`** — keeps the dependency, drops the hardcoded version. Go really uses it: `GoVerifier.java` imports `org.sonarsource.analyzer.commons.checks.verifier.SingleFileVerifier`.

**`csharp/pom.xml`** — the dependency is removed. It was unused. No C# test imports anything from `org.sonarsource.analyzer.commons`. The `RuleMetadataLoader` in `CSharpScannerRuleDefinition` comes from `sonar-analyzer-commons`, which is a different artifact, compile‑scoped and transitive — a test‑scoped dependency could never have supplied it.

This uses `dependencyManagement`, not the parent `<dependencies>` block, so no other module gains a dependency it does not use.

## Verification

Resolved version in `go` comes from the parent:

```
$ mvn -pl go dependency:tree -Dincludes=org.sonarsource.analyzer-commons
+- org.sonarsource.analyzer-commons:sonar-analyzer-test-commons:jar:2.30.0.5193:test
```

The other `analyzer-commons` artifacts still show `2.18.0.3393` in that tree. Those are transitive from the Sonar Go plugin and are not declared here.

Build and tests:

```
$ mvn test -pl csharp,go -am
BUILD SUCCESS
  go:     41 tests, 0 failures, 0 errors, 1 skipped
  csharp: 19 tests, 0 failures, 0 errors, 0 skipped
```

The skipped Go test is `CrossFileHookDetachTest`, which is skipped by design because Go has no hooks. It is unrelated to this change.

Closes #513
