### PR TITLE
Added .with[Optional]NamedParameter and tests

### DIFF
--- a/engine/src/main/java/com/ibm/engine/language/python/PythonDetectionEngine.java
+++ b/engine/src/main/java/com/ibm/engine/language/python/PythonDetectionEngine.java
@@ -40,6 +40,7 @@ import org.sonar.plugins.python.api.symbols.Symbol;
 import org.sonar.plugins.python.api.tree.*;
 
 public class PythonDetectionEngine implements IDetectionEngine<Tree, Symbol> {
+
     @Nonnull
     private final DetectionStore<PythonCheck, Tree, Symbol, PythonVisitorContext> detectionStore;
 
@@ -351,6 +352,26 @@ public class PythonDetectionEngine implements IDetectionEngine<Tree, Symbol> {
     @Nonnull
     private Optional<TraceSymbol<Symbol>> getTraceSymbol(
             @Nonnull Parameter<Tree> parameter, @Nonnull List<Argument> arguments) {
+        Optional<String> keywordName = parameter.getKeywordName();
+        if (keywordName.isPresent()) {
+            // Named parameter: keyword-name lookup first, then positional fallback
+            Optional<Argument> resolved =
+                    findArgumentByKeyword(keywordName.get(), parameter.getIndex(), arguments);
+            if (resolved.isEmpty()) {
+                return Optional.of(TraceSymbol.createWithStateDifferent());
+            }
+            Argument arg = resolved.get();
+            if (arg instanceof RegularArgument regularArg) {
+                Expression expressionArg = regularArg.expression();
+                if (expressionArg.is(Tree.Kind.NAME)) {
+                    Name nameArg = (Name) expressionArg;
+                    return Optional.of(TraceSymbol.createFrom(nameArg.symbol()));
+                }
+            }
+            return Optional.of(TraceSymbol.createWithStateNoSymbol());
+        }
+
+        // Positional parameter (original behaviour)
         if (parameter.getIndex() >= arguments.size()) {
             return Optional.of(TraceSymbol.createWithStateDifferent());
         }
@@ -414,10 +435,6 @@ public class PythonDetectionEngine implements IDetectionEngine<Tree, Symbol> {
         }
 
         DetectionRule<Tree> detectionRule = (DetectionRule<Tree>) detectionStore.getDetectionRule();
-        if (detectionRule.actionFactory() != null) {
-            MethodDetection<Tree> methodDetection = new MethodDetection<>(expressionTree, null);
-            detectionStore.onReceivingNewDetection(methodDetection);
-        }
 
         // Extracts the arguments for the provided expression
         List<Argument> arguments = expressionTree.arguments();
@@ -427,57 +444,208 @@ public class PythonDetectionEngine implements IDetectionEngine<Tree, Symbol> {
         // TODO: It would be better to have a case disjunction to use either
         // isInvocationOnVariable or isInitForVariable, but it is difficult in Python
 
-        int index = 0;
-        for (Parameter<Tree> parameter : detectionRule.parameters()) {
-            if (!checkCurrentIndexState(
-                    index, arguments, isInvocation, traceSymbol, expressionTree)) {
-                index++;
-                continue;
-            }
-            // the expression tree of the parameter
-            Tree expression = arguments.get(index); // this is an Argument tree
-            if (expression instanceof RegularArgument regularArgument) {
-                expression = regularArgument.expression();
+        // When named parameters are present, reject unpacking arguments (*args, **kwargs) since
+        // we cannot statically inspect their contents, and reject calls where a required named
+        // parameter is absent. Unknown keyword arguments are silently ignored — we assume valid
+        // Python code where argument order is positional → named required → named optional.
+        boolean hasNamedParams =
+                detectionRule.parameters().stream().anyMatch(p -> p.getKeywordName().isPresent());
+        if (hasNamedParams) {
+            // Reject if any argument is a dict-unpacking (**d) or sequence-unpacking (*args).
+            boolean hasUnpackingArg =
+                    arguments.stream().anyMatch(a -> !(a instanceof RegularArgument));
+            if (hasUnpackingArg) {
+                return;
             }
 
-            /*
-             * This method resolves the detection parameter in an inner scope.
-             * If unsuccessful, it falls back to resolving values in the outer scope using the provided expression and detectableParameter.
-             */
-            if (parameter.is(DetectableParameter.class)) {
-                DetectableParameter<Tree> detectableParameter =
-                        (DetectableParameter<Tree>) parameter;
-                // try to resolve value in inner scope
-                List<ResolvedValue<Object, Tree>> resolvedValues =
-                        resolveValuesInInnerScope(
-                                Object.class, expression, detectableParameter.getiValueFactory());
-                if (resolvedValues.isEmpty()) {
-                    // goto outer scope
-                    resolveValuesInOuterScope(expression, detectableParameter);
-                } else {
-                    resolvedValues.stream()
-                            .map(
-                                    resolvedValue ->
-                                            new ValueDetection<>(
-                                                    resolvedValue,
-                                                    detectableParameter,
-                                                    expressionTree,
-                                                    expressionTree))
-                            .forEach(detectionStore::onReceivingNewDetection);
+            // Reject calls whose argument count is less than
+            //   minArgs = positional params + required named params
+            // Too few args means at least one required param cannot be satisfied.
+            int minArgs =
+                    (int)
+                            detectionRule.parameters().stream()
+                                    .filter(
+                                            p ->
+                                                    p.getKeywordName().isEmpty()
+                                                            || !p.isKeywordOptional())
+                                    .count();
+            if (arguments.size() < minArgs) {
+                return;
+            }
+
+            // Reject if any required named parameter is absent from the call site.
+            for (Parameter<Tree> p : detectionRule.parameters()) {
+                if (p.getKeywordName().isPresent() && !p.isKeywordOptional()) {
+                    Optional<Argument> present =
+                            findArgumentByKeyword(
+                                    p.getKeywordName().get(), p.getIndex(), arguments);
+                    if (present.isEmpty()) {
+                        return;
+                    }
                 }
-            } else if (!parameter.getDetectionRules().isEmpty()) {
-                /*
-                 * This case is reached when the parameter is not a DetectableParameter (the rule does not contains `.shouldBeDetectedAs`),
-                 * but has depending detection rules (the rule contain `.addDependingDetectionRules`).
-                 * This happens usually for parameters that are intermediary function, that we have to resolve but we don't want to capture their value.
-                 * In this case, we resolve the parameter with the depending detection rule with an EXPRESSION scope,
-                 * this way we ensure to only resolve the right parameter content and not similar calls in the same function scope.
-                 */
-                detectionStore.onDetectedDependingParameter(
-                        parameter, expression, DetectionStore.Scope.EXPRESSION);
             }
 
-            index++;
+            // Reject if any positional parameter's type does not match its declaration.
+            // This must run before the root MethodDetection is emitted so a type mismatch
+            // on a positional slot suppresses the entire rule, not just that parameter.
+            for (Parameter<Tree> p : detectionRule.parameters()) {
+                if (p.getKeywordName().isPresent()
+                        || p.getParameterType().equals(MethodMatcher.ANY)) {
+                    continue;
+                }
+                if (p.getIndex() >= arguments.size()) {
+                    continue;
+                }
+                Tree argTree = arguments.get(p.getIndex());
+                if (argTree instanceof RegularArgument ra) {
+                    argTree = ra.expression();
+                }
+                Optional<IType> resolvedType = PythonSemantic.resolveTreeType(argTree);
+                boolean typeMatches =
+                        resolvedType.map(t -> t.is(p.getParameterType())).orElse(true);
+                if (!typeMatches) {
+                    return;
+                }
+            }
+        }
+
+        if (detectionRule.actionFactory() != null) {
+            MethodDetection<Tree> methodDetection = new MethodDetection<>(expressionTree, null);
+            detectionStore.onReceivingNewDetection(methodDetection);
+        }
+
+        for (Parameter<Tree> parameter : detectionRule.parameters()) {
+            Optional<String> keywordName = parameter.getKeywordName();
+
+            if (keywordName.isPresent()) {
+                // --- Named parameter extraction ---
+                Optional<Argument> resolvedArg =
+                        findArgumentByKeyword(keywordName.get(), parameter.getIndex(), arguments);
+
+                if (resolvedArg.isEmpty()) {
+                    // optional parameter absent → skip silently;
+                    // required parameter absent → pre-flight already rejected the call above
+                    continue;
+                }
+
+                // extract expression from the resolved argument
+                Tree expression = resolvedArg.get();
+                if (expression instanceof RegularArgument regularArgument) {
+                    expression = regularArgument.expression();
+                }
+
+                // Type check: verify the resolved argument's type against the declared parameter
+                // type. Skipped when the declared type is ANY (wildcard). When the type cannot be
+                // statically resolved, resolveTreeType returns an accept-all IType — the same
+                // conservative behaviour used by MethodMatcher for positional parameters.
+                if (!parameter.getParameterType().equals(MethodMatcher.ANY)) {
+                    Optional<IType> resolvedType = PythonSemantic.resolveTreeType(expression);
+                    boolean typeMatches =
+                            resolvedType.map(t -> t.is(parameter.getParameterType())).orElse(true);
+                    if (!typeMatches) {
+                        // Type mismatch: skip optional, stop for required
+                        if (!parameter.isKeywordOptional()) {
+                            return;
+                        }
+                        continue;
+                    }
+                }
+
+                if (!checkSymbolTraceState(isInvocation, traceSymbol, expressionTree)) {
+                    continue;
+                }
+
+                processParameterExpression(parameter, expression, expressionTree);
+            } else {
+                // --- Positional parameter extraction (original behaviour) ---
+                if (!checkCurrentIndexState(
+                        parameter.getIndex(),
+                        arguments,
+                        isInvocation,
+                        traceSymbol,
+                        expressionTree)) {
+                    continue;
+                }
+                Tree expression = arguments.get(parameter.getIndex());
+                if (expression instanceof RegularArgument regularArgument) {
+                    expression = regularArgument.expression();
+                }
+
+                processParameterExpression(parameter, expression, expressionTree);
+            }
+        }
+    }
+
+    /**
+     * Tries to find an argument matching the given keyword name. Falls back to the positional index
+     * if no keyword-named argument is found and the argument at that index is positional (i.e. has
+     * no keyword name itself).
+     *
+     * @param keywordName the name to look for as a keyword argument
+     * @param positionalIndex the fallback positional index
+     * @param arguments the full argument list at the call site
+     * @return the matching argument, or empty if neither keyword nor positional match is available
+     */
+    @Nonnull
+    private Optional<Argument> findArgumentByKeyword(
+            @Nonnull String keywordName, int positionalIndex, @Nonnull List<Argument> arguments) {
+        // Step 1: keyword-name lookup
+        for (Argument arg : arguments) {
+            if (arg instanceof RegularArgument ra
+                    && ra.keywordArgument() != null
+                    && keywordName.equals(ra.keywordArgument().name())) {
+                return Optional.of(arg);
+            }
+        }
+        // Step 2: positional fallback — accept only if the argument at positionalIndex is itself
+        // positional (no keyword marker) to avoid misattributing a keyword arg to the wrong param.
+        if (positionalIndex < arguments.size()) {
+            Argument arg = arguments.get(positionalIndex);
+            if (arg instanceof RegularArgument ra && ra.keywordArgument() == null) {
+                return Optional.of(arg);
+            }
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * Shared logic for processing a resolved parameter expression (both positional and named
+     * parameters). Mirrors the inner body of the original analyseExpression loop.
+     */
+    private void processParameterExpression(
+            @Nonnull Parameter<Tree> parameter,
+            @Nonnull Tree expression,
+            @Nonnull CallExpression expressionTree) {
+        if (parameter.is(DetectableParameter.class)) {
+            DetectableParameter<Tree> detectableParameter = (DetectableParameter<Tree>) parameter;
+            // try to resolve value in inner scope
+            List<ResolvedValue<Object, Tree>> resolvedValues =
+                    resolveValuesInInnerScope(
+                            Object.class, expression, detectableParameter.getiValueFactory());
+            if (resolvedValues.isEmpty()) {
+                // goto outer scope
+                resolveValuesInOuterScope(expression, detectableParameter);
+            } else {
+                resolvedValues.stream()
+                        .map(
+                                resolvedValue ->
+                                        new ValueDetection<>(
+                                                resolvedValue,
+                                                detectableParameter,
+                                                expressionTree,
+                                                expressionTree))
+                        .forEach(detectionStore::onReceivingNewDetection);
+            }
+        } else if (!parameter.getDetectionRules().isEmpty()) {
+            /*
+             * This case is reached when the parameter is not a DetectableParameter (the rule does not contains `.shouldBeDetectedAs`),
+             * but has depending detection rules (the rule contain `.addDependingDetectionRules`).
+             * This happens usually for parameters that are intermediary function, that we have to resolve but we don't want to capture their value.
+             * In this case, we resolve the parameter with the depending detection rule with an EXPRESSION scope,
+             * this way we ensure to only resolve the right parameter content and not similar calls in the same function scope.
+             */
+            detectionStore.onDetectedDependingParameter(
+                    parameter, expression, DetectionStore.Scope.EXPRESSION);
         }
     }
 
@@ -496,6 +664,19 @@ public class PythonDetectionEngine implements IDetectionEngine<Tree, Symbol> {
             return false;
         }
 
+        return checkSymbolTraceState(isInvocation, traceSymbol, expressionTree);
+    }
+
+    /**
+     * Checks whether the call-graph symbol-trace context allows the rule to fire. This is the
+     * second half of {@link #checkCurrentIndexState} without the arity guard, and is used on the
+     * named-parameter path where the argument has already been resolved by keyword name and its
+     * physical existence is guaranteed by {@link #findArgumentByKeyword}.
+     */
+    private boolean checkSymbolTraceState(
+            boolean isInvocation,
+            @Nonnull TraceSymbol<Symbol> traceSymbol,
+            @Nonnull CallExpression expressionTree) {
         // Check if the variable symbols for the method (if applicable) are connected
         Optional<Symbol> assignedSymbol =
                 getAssignedSymbol(expressionTree).map(ts -> ts.getSymbol());

--- a/engine/src/main/java/com/ibm/engine/rule/DetectableParameter.java
+++ b/engine/src/main/java/com/ibm/engine/rule/DetectableParameter.java
@@ -41,7 +41,30 @@ public class DetectableParameter<T> extends Parameter<T> {
                 parameterType,
                 index,
                 shouldMatchExactTypes,
-                detectionRules);
+                detectionRules,
+                null,
+                false);
+        this.iValueFactory = iValueFactory;
+        this.shouldBeMovedUnder = shouldBeMovedUnder;
+    }
+
+    public DetectableParameter(
+            @Nonnull String parameterType,
+            int index,
+            boolean shouldMatchExactTypes,
+            @Nonnull IValueFactory<T> iValueFactory,
+            @Nonnull List<IDetectionRule<T>> detectionRules,
+            @Nullable Integer shouldBeMovedUnder,
+            @Nullable String keywordName,
+            boolean keywordOptional) {
+        super(
+                DetectableParameter.class,
+                parameterType,
+                index,
+                shouldMatchExactTypes,
+                detectionRules,
+                keywordName,
+                keywordOptional);
         this.iValueFactory = iValueFactory;
         this.shouldBeMovedUnder = shouldBeMovedUnder;
     }

--- a/engine/src/main/java/com/ibm/engine/rule/IDetectionRule.java
+++ b/engine/src/main/java/com/ibm/engine/rule/IDetectionRule.java
@@ -72,6 +72,14 @@ public interface IDetectionRule<T> {
 
         @Nonnull
         ParametersFactoryBuilder<T> withMethodParameterMatchExactType(@Nonnull String type);
+
+        @Nonnull
+        ParametersFactoryBuilder<T> withNamedMethodParameter(
+                @Nonnull String name, @Nonnull String type);
+
+        @Nonnull
+        ParametersFactoryBuilder<T> withOptionalNamedMethodParameter(
+                @Nonnull String name, @Nonnull String type);
     }
 
     interface ParametersTypeBuilder<T> {
@@ -80,6 +88,14 @@ public interface IDetectionRule<T> {
 
         @Nonnull
         ParametersFactoryBuilder<T> withMethodParameterMatchExactType(@Nonnull String type);
+
+        @Nonnull
+        ParametersFactoryBuilder<T> withNamedMethodParameter(
+                @Nonnull String name, @Nonnull String type);
+
+        @Nonnull
+        ParametersFactoryBuilder<T> withOptionalNamedMethodParameter(
+                @Nonnull String name, @Nonnull String type);
 
         @Nonnull
         FinalDetectionRuleBuilder<T> withoutParameters();
@@ -94,6 +110,14 @@ public interface IDetectionRule<T> {
 
         @Nonnull
         ParametersFactoryBuilder<T> withMethodParameterMatchExactType(@Nonnull String type);
+
+        @Nonnull
+        ParametersFactoryBuilder<T> withNamedMethodParameter(
+                @Nonnull String name, @Nonnull String type);
+
+        @Nonnull
+        ParametersFactoryBuilder<T> withOptionalNamedMethodParameter(
+                @Nonnull String name, @Nonnull String type);
 
         @Nonnull
         PositionBuilder<T> shouldBeDetectedAs(@Nonnull IValueFactory<T> valueFactory);
@@ -115,6 +139,14 @@ public interface IDetectionRule<T> {
         ParametersFactoryBuilder<T> withMethodParameterMatchExactType(@Nonnull String type);
 
         @Nonnull
+        ParametersFactoryBuilder<T> withNamedMethodParameter(
+                @Nonnull String name, @Nonnull String type);
+
+        @Nonnull
+        ParametersFactoryBuilder<T> withOptionalNamedMethodParameter(
+                @Nonnull String name, @Nonnull String type);
+
+        @Nonnull
         ParametersDependingRulesBuilder<T> asChildOfParameterWithId(int id);
 
         @Nonnull
@@ -134,6 +166,14 @@ public interface IDetectionRule<T> {
         ParametersFactoryBuilder<T> withMethodParameterMatchExactType(@Nonnull String type);
 
         @Nonnull
+        ParametersFactoryBuilder<T> withNamedMethodParameter(
+                @Nonnull String name, @Nonnull String type);
+
+        @Nonnull
+        ParametersFactoryBuilder<T> withOptionalNamedMethodParameter(
+                @Nonnull String name, @Nonnull String type);
+
+        @Nonnull
         ParametersFinalDetectionRuleBuilder<T> addDependingDetectionRules(
                 @Nonnull List<IDetectionRule<T>> detectionRules);
 
@@ -148,6 +188,14 @@ public interface IDetectionRule<T> {
 
         @Nonnull
         ParametersFactoryBuilder<T> withMethodParameterMatchExactType(@Nonnull String type);
+
+        @Nonnull
+        ParametersFactoryBuilder<T> withNamedMethodParameter(
+                @Nonnull String name, @Nonnull String type);
+
+        @Nonnull
+        ParametersFactoryBuilder<T> withOptionalNamedMethodParameter(
+                @Nonnull String name, @Nonnull String type);
 
         @Nonnull
         AddBundleDetectionRuleBuilder<T> buildForContext(

--- a/engine/src/main/java/com/ibm/engine/rule/Parameter.java
+++ b/engine/src/main/java/com/ibm/engine/rule/Parameter.java
@@ -20,7 +20,9 @@
 package com.ibm.engine.rule;
 
 import java.util.List;
+import java.util.Optional;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 public class Parameter<T> {
     @Nonnull protected final List<IDetectionRule<T>> detectionRules;
@@ -29,17 +31,30 @@ public class Parameter<T> {
     protected boolean shouldMatchExactTypes;
     protected final int index;
 
+    /**
+     * Non-null when this parameter was declared with {@code withNamedMethodParameter} or {@code
+     * withOptionalNamedMethodParameter}.
+     */
+    @Nullable private final String keywordName;
+
+    /** True when this named parameter may be absent from the call site. */
+    private final boolean keywordOptional;
+
     protected Parameter(
             @Nonnull Class<? extends Parameter> type,
             @Nonnull String parameterType,
             int index,
             boolean shouldMatchExactTypes,
-            @Nonnull List<IDetectionRule<T>> detectionRules) {
+            @Nonnull List<IDetectionRule<T>> detectionRules,
+            @Nullable String keywordName,
+            boolean keywordOptional) {
         this.type = type;
         this.parameterType = parameterType;
         this.index = index;
         this.shouldMatchExactTypes = shouldMatchExactTypes;
         this.detectionRules = detectionRules;
+        this.keywordName = keywordName;
+        this.keywordOptional = keywordOptional;
     }
 
     public Parameter(
@@ -52,6 +67,24 @@ public class Parameter<T> {
         this.index = index;
         this.shouldMatchExactTypes = shouldMatchExactTypes;
         this.detectionRules = detectionRules;
+        this.keywordName = null;
+        this.keywordOptional = false;
+    }
+
+    public Parameter(
+            @Nonnull String parameterType,
+            int index,
+            boolean shouldMatchExactTypes,
+            @Nonnull List<IDetectionRule<T>> detectionRules,
+            @Nullable String keywordName,
+            boolean keywordOptional) {
+        this.type = Parameter.class;
+        this.parameterType = parameterType;
+        this.index = index;
+        this.shouldMatchExactTypes = shouldMatchExactTypes;
+        this.detectionRules = detectionRules;
+        this.keywordName = keywordName;
+        this.keywordOptional = keywordOptional;
     }
 
     public boolean is(@Nonnull Class<? extends Parameter> type) {
@@ -74,5 +107,19 @@ public class Parameter<T> {
     @Nonnull
     public List<IDetectionRule<T>> getDetectionRules() {
         return detectionRules;
+    }
+
+    /** Returns the keyword-argument name if this is a named parameter, otherwise empty. */
+    @Nonnull
+    public Optional<String> getKeywordName() {
+        return Optional.ofNullable(keywordName);
+    }
+
+    /**
+     * Returns {@code true} when this is a named parameter that may be absent at the call site
+     * without preventing a match.
+     */
+    public boolean isKeywordOptional() {
+        return keywordOptional;
     }
 }

--- a/engine/src/main/java/com/ibm/engine/rule/builder/DetectionRuleBuilderImpl.java
+++ b/engine/src/main/java/com/ibm/engine/rule/builder/DetectionRuleBuilderImpl.java
@@ -50,6 +50,20 @@ final class DetectionRuleBuilderImpl<T>
     @Nullable private IBundle bundle;
     private boolean shouldMatchExactTypes;
 
+    /**
+     * Set to {@code true} as soon as the first {@code withNamedMethodParameter} or {@code
+     * withOptionalNamedMethodParameter} call is made. Subsequent {@code withMethodParameter} calls
+     * after this point are illegal.
+     */
+    private boolean namedParameterAdded;
+
+    /**
+     * Set to {@code true} as soon as a {@code withOptionalNamedMethodParameter} is committed. A
+     * subsequent {@code withNamedMethodParameter} (required) is illegal because Python's calling
+     * convention requires required named parameters to precede optional ones.
+     */
+    private boolean optionalNamedParameterAdded;
+
     @Nonnull
     private LinkedList<IDetectionRule<T>> invokedObjectDependingDetectionRules = new LinkedList<>();
 
@@ -61,12 +75,17 @@ final class DetectionRuleBuilderImpl<T>
     @Nonnull private LinkedList<IDetectionRule<T>> detectionRules = new LinkedList<>();
     @Nullable private Integer positionMove;
     private boolean parameterShouldMatchExactTypes;
+    // named-parameter fields for the parameter currently being assembled
+    @Nullable private String pendingKeywordName;
+    private boolean pendingKeywordOptional;
 
     public DetectionRuleBuilderImpl() {
         // nothing
         buildingNewDetectionParameter = false;
         shouldMatchExactTypes = false;
         parameterShouldMatchExactTypes = false;
+        namedParameterAdded = false;
+        optionalNamedParameterAdded = false;
     }
 
     @SuppressWarnings("all")
@@ -85,7 +104,11 @@ final class DetectionRuleBuilderImpl<T>
             @Nullable Integer positionMove,
             boolean parameterShouldMatchExactTypes,
             boolean buildingNewDetectionParameter,
-            @Nullable IBundle bundle) {
+            @Nullable IBundle bundle,
+            boolean namedParameterAdded,
+            boolean optionalNamedParameterAdded,
+            @Nullable String pendingKeywordName,
+            boolean pendingKeywordOptional) {
         this.objectTypes = objectTypes;
         this.methodNames = methodNames;
         this.parameters = parameters;
@@ -104,12 +127,14 @@ final class DetectionRuleBuilderImpl<T>
         this.buildingNewDetectionParameter = buildingNewDetectionParameter;
 
         this.bundle = bundle;
+        this.namedParameterAdded = namedParameterAdded;
+        this.optionalNamedParameterAdded = optionalNamedParameterAdded;
+        this.pendingKeywordName = pendingKeywordName;
+        this.pendingKeywordOptional = pendingKeywordOptional;
     }
 
     @Nonnull
-    @Override
-    public IDetectionRule.NameBuilder<T> forObjectTypes(@Nonnull String... types) {
-        this.objectTypes = types;
+    private DetectionRuleBuilderImpl<T> copy() {
         return new DetectionRuleBuilderImpl<>(
                 objectTypes,
                 methodNames,
@@ -125,7 +150,18 @@ final class DetectionRuleBuilderImpl<T>
                 positionMove,
                 parameterShouldMatchExactTypes,
                 buildingNewDetectionParameter,
-                bundle);
+                bundle,
+                namedParameterAdded,
+                optionalNamedParameterAdded,
+                pendingKeywordName,
+                pendingKeywordOptional);
+    }
+
+    @Nonnull
+    @Override
+    public IDetectionRule.NameBuilder<T> forObjectTypes(@Nonnull String... types) {
+        this.objectTypes = types;
+        return copy();
     }
 
     @Nonnull
@@ -133,44 +169,14 @@ final class DetectionRuleBuilderImpl<T>
     public IDetectionRule.NameBuilder<T> forObjectExactTypes(@Nonnull String... types) {
         this.objectTypes = types;
         this.shouldMatchExactTypes = true;
-        return new DetectionRuleBuilderImpl<>(
-                objectTypes,
-                methodNames,
-                parameters,
-                capturedParameterScope,
-                detectionValueContext,
-                shouldMatchExactTypes,
-                invokedObjectDependingDetectionRules,
-                parameterType,
-                iValueFactory,
-                iActionFactory,
-                detectionRules,
-                positionMove,
-                parameterShouldMatchExactTypes,
-                buildingNewDetectionParameter,
-                bundle);
+        return copy();
     }
 
     @Nonnull
     @Override
     public IDetectionRule.ActionDetectionBuilder<T> forMethods(@Nonnull String... names) {
         this.methodNames = names;
-        return new DetectionRuleBuilderImpl<>(
-                objectTypes,
-                methodNames,
-                parameters,
-                capturedParameterScope,
-                detectionValueContext,
-                shouldMatchExactTypes,
-                invokedObjectDependingDetectionRules,
-                parameterType,
-                iValueFactory,
-                iActionFactory,
-                detectionRules,
-                positionMove,
-                parameterShouldMatchExactTypes,
-                buildingNewDetectionParameter,
-                bundle);
+        return copy();
     }
 
     @Nonnull
@@ -178,140 +184,90 @@ final class DetectionRuleBuilderImpl<T>
     public IDetectionRule.ActionDetectionBuilder<T> forConstructor() {
         this.methodNames = new String[1];
         this.methodNames[0] = "<init>";
-        return new DetectionRuleBuilderImpl<>(
-                objectTypes,
-                methodNames,
-                parameters,
-                capturedParameterScope,
-                detectionValueContext,
-                shouldMatchExactTypes,
-                invokedObjectDependingDetectionRules,
-                parameterType,
-                iValueFactory,
-                iActionFactory,
-                detectionRules,
-                positionMove,
-                parameterShouldMatchExactTypes,
-                buildingNewDetectionParameter,
-                bundle);
+        return copy();
     }
 
     @Nonnull
     public IDetectionRule.ParametersTypeBuilder<T> shouldBeDetectedAs(
             @Nonnull IActionFactory<T> actionFactory) {
         this.iActionFactory = actionFactory;
-        return new DetectionRuleBuilderImpl<>(
-                objectTypes,
-                methodNames,
-                parameters,
-                capturedParameterScope,
-                detectionValueContext,
-                shouldMatchExactTypes,
-                invokedObjectDependingDetectionRules,
-                parameterType,
-                iValueFactory,
-                iActionFactory,
-                detectionRules,
-                positionMove,
-                parameterShouldMatchExactTypes,
-                buildingNewDetectionParameter,
-                bundle);
+        return copy();
     }
 
     @Nonnull
     @Override
     public IDetectionRule.ParametersFactoryBuilder<T> withMethodParameter(@Nonnull String type) {
+        if (namedParameterAdded) {
+            throw new IllegalStateException(
+                    "withMethodParameter() must precede all withNamedMethodParameter() and withOptionalNamedMethodParameter() declarations.");
+        }
         checkDetectionParameterState();
         this.buildingNewDetectionParameter = false;
         this.capturedParameterScope = CapturedParameterScope.SOME;
         this.parameterType = type;
-        return new DetectionRuleBuilderImpl<>(
-                objectTypes,
-                methodNames,
-                parameters,
-                capturedParameterScope,
-                detectionValueContext,
-                shouldMatchExactTypes,
-                invokedObjectDependingDetectionRules,
-                parameterType,
-                iValueFactory,
-                iActionFactory,
-                detectionRules,
-                positionMove,
-                parameterShouldMatchExactTypes,
-                buildingNewDetectionParameter,
-                bundle);
+        return copy();
     }
 
     @Nonnull
     @Override
     public IDetectionRule.ParametersFactoryBuilder<T> withMethodParameterMatchExactType(
             @Nonnull String type) {
+        if (namedParameterAdded) {
+            throw new IllegalStateException(
+                    "withMethodParameterMatchExactType() must precede all withNamedMethodParameter() and withOptionalNamedMethodParameter() declarations.");
+        }
         checkDetectionParameterState();
         this.buildingNewDetectionParameter = false;
         this.capturedParameterScope = CapturedParameterScope.SOME;
         this.parameterType = type;
         this.parameterShouldMatchExactTypes = true;
-        return new DetectionRuleBuilderImpl<>(
-                objectTypes,
-                methodNames,
-                parameters,
-                capturedParameterScope,
-                detectionValueContext,
-                shouldMatchExactTypes,
-                invokedObjectDependingDetectionRules,
-                parameterType,
-                iValueFactory,
-                iActionFactory,
-                detectionRules,
-                positionMove,
-                parameterShouldMatchExactTypes,
-                buildingNewDetectionParameter,
-                bundle);
+        return copy();
+    }
+
+    @Nonnull
+    @Override
+    public IDetectionRule.ParametersFactoryBuilder<T> withNamedMethodParameter(
+            @Nonnull String name, @Nonnull String type) {
+        checkDetectionParameterState();
+        if (optionalNamedParameterAdded) {
+            throw new IllegalStateException(
+                    "withNamedMethodParameter() must precede all withOptionalNamedMethodParameter() declarations.");
+        }
+        this.buildingNewDetectionParameter = false;
+        this.capturedParameterScope = CapturedParameterScope.SOME;
+        this.parameterType = type;
+        this.namedParameterAdded = true;
+        this.pendingKeywordName = name;
+        this.pendingKeywordOptional = false;
+        return copy();
+    }
+
+    @Nonnull
+    @Override
+    public IDetectionRule.ParametersFactoryBuilder<T> withOptionalNamedMethodParameter(
+            @Nonnull String name, @Nonnull String type) {
+        checkDetectionParameterState();
+        this.buildingNewDetectionParameter = false;
+        this.capturedParameterScope = CapturedParameterScope.SOME;
+        this.parameterType = type;
+        this.namedParameterAdded = true;
+        this.pendingKeywordName = name;
+        this.pendingKeywordOptional = true;
+        return copy();
     }
 
     @Nonnull
     @Override
     public IDetectionRule.FinalDetectionRuleBuilder<T> withoutParameters() {
         capturedParameterScope = CapturedParameterScope.NONE;
-        return new DetectionRuleBuilderImpl<>(
-                objectTypes,
-                methodNames,
-                parameters,
-                capturedParameterScope,
-                detectionValueContext,
-                shouldMatchExactTypes,
-                invokedObjectDependingDetectionRules,
-                parameterType,
-                iValueFactory,
-                iActionFactory,
-                detectionRules,
-                positionMove,
-                parameterShouldMatchExactTypes,
-                buildingNewDetectionParameter,
-                bundle);
+        return copy();
     }
 
     @Nonnull
     @Override
     public IDetectionRule.FinalDetectionRuleBuilder<T> withAnyParameters() {
         capturedParameterScope = CapturedParameterScope.ANY;
-        return new DetectionRuleBuilderImpl<>(
-                objectTypes,
-                methodNames,
-                parameters,
-                capturedParameterScope,
-                detectionValueContext,
-                shouldMatchExactTypes,
-                invokedObjectDependingDetectionRules,
-                parameterType,
-                iValueFactory,
-                iActionFactory,
-                detectionRules,
-                positionMove,
-                parameterShouldMatchExactTypes,
-                buildingNewDetectionParameter,
-                bundle);
+        return copy();
     }
 
     @Nonnull
@@ -319,22 +275,7 @@ final class DetectionRuleBuilderImpl<T>
     public IDetectionRule.ParametersDependingRulesBuilder<T> asChildOfParameterWithId(int id) {
         this.buildingNewDetectionParameter = true;
         this.positionMove = id;
-        return new DetectionRuleBuilderImpl<>(
-                objectTypes,
-                methodNames,
-                parameters,
-                capturedParameterScope,
-                detectionValueContext,
-                shouldMatchExactTypes,
-                invokedObjectDependingDetectionRules,
-                parameterType,
-                iValueFactory,
-                iActionFactory,
-                detectionRules,
-                positionMove,
-                parameterShouldMatchExactTypes,
-                buildingNewDetectionParameter,
-                bundle);
+        return copy();
     }
 
     @Nonnull
@@ -342,22 +283,7 @@ final class DetectionRuleBuilderImpl<T>
     public IDetectionRule.AddBundleDetectionRuleBuilder<T> buildForContext(
             @Nonnull IDetectionContext detectionValueContext) {
         this.detectionValueContext = detectionValueContext;
-        return new DetectionRuleBuilderImpl<>(
-                objectTypes,
-                methodNames,
-                parameters,
-                capturedParameterScope,
-                detectionValueContext,
-                shouldMatchExactTypes,
-                invokedObjectDependingDetectionRules,
-                parameterType,
-                iValueFactory,
-                iActionFactory,
-                detectionRules,
-                positionMove,
-                parameterShouldMatchExactTypes,
-                buildingNewDetectionParameter,
-                bundle);
+        return copy();
     }
 
     @Nonnull
@@ -381,7 +307,11 @@ final class DetectionRuleBuilderImpl<T>
                 positionMove,
                 parameterShouldMatchExactTypes,
                 buildingNewDetectionParameter,
-                bundle);
+                bundle,
+                namedParameterAdded,
+                optionalNamedParameterAdded,
+                pendingKeywordName,
+                pendingKeywordOptional);
     }
 
     @Nonnull
@@ -390,22 +320,7 @@ final class DetectionRuleBuilderImpl<T>
             @Nonnull IValueFactory<T> valueFactory) {
         this.buildingNewDetectionParameter = true;
         this.iValueFactory = valueFactory;
-        return new DetectionRuleBuilderImpl<>(
-                objectTypes,
-                methodNames,
-                parameters,
-                capturedParameterScope,
-                detectionValueContext,
-                shouldMatchExactTypes,
-                invokedObjectDependingDetectionRules,
-                parameterType,
-                iValueFactory,
-                iActionFactory,
-                detectionRules,
-                positionMove,
-                parameterShouldMatchExactTypes,
-                buildingNewDetectionParameter,
-                bundle);
+        return copy();
     }
 
     @Nonnull
@@ -413,22 +328,7 @@ final class DetectionRuleBuilderImpl<T>
     public IDetectionRule.InvokedObjectDependingDetectionRules<T> inBundle(
             @Nonnull IBundle bundle) {
         this.bundle = bundle;
-        return new DetectionRuleBuilderImpl<>(
-                objectTypes,
-                methodNames,
-                parameters,
-                capturedParameterScope,
-                detectionValueContext,
-                shouldMatchExactTypes,
-                invokedObjectDependingDetectionRules,
-                parameterType,
-                iValueFactory,
-                iActionFactory,
-                detectionRules,
-                positionMove,
-                parameterShouldMatchExactTypes,
-                buildingNewDetectionParameter,
-                bundle);
+        return copy();
     }
 
     @Nonnull
@@ -485,11 +385,21 @@ final class DetectionRuleBuilderImpl<T>
                     bundle,
                     invokedObjectDependingDetectionRules);
         } else {
-            final MethodMatcher<T> methodMatcher =
-                    new MethodMatcher<>(
-                            this.objectTypes,
-                            this.methodNames,
-                            this.parameters.stream().map(Parameter::getParameterType).toList());
+            // If any parameter is a named parameter, use the no-type-list MethodMatcher so that
+            // the matcher accepts any call to the method and delegates structural matching to
+            // the extraction loop in the engine (proposal §2.1).
+            final boolean hasNamedParams =
+                    parameters.stream().anyMatch(p -> p.getKeywordName().isPresent());
+            final MethodMatcher<T> methodMatcher;
+            if (hasNamedParams) {
+                methodMatcher = new MethodMatcher<>(this.objectTypes, this.methodNames);
+            } else {
+                methodMatcher =
+                        new MethodMatcher<>(
+                                this.objectTypes,
+                                this.methodNames,
+                                this.parameters.stream().map(Parameter::getParameterType).toList());
+            }
 
             return new DetectionRule<>(
                     methodMatcher,
@@ -509,29 +419,71 @@ final class DetectionRuleBuilderImpl<T>
 
         if (this.buildingNewDetectionParameter) {
             if (iValueFactory == null) {
+                if (pendingKeywordName != null) {
+                    this.parameters.add(
+                            new Parameter<>(
+                                    parameterType,
+                                    this.parameters.size(),
+                                    parameterShouldMatchExactTypes,
+                                    detectionRules,
+                                    pendingKeywordName,
+                                    pendingKeywordOptional));
+                } else {
+                    this.parameters.add(
+                            new Parameter<>(
+                                    parameterType,
+                                    this.parameters.size(),
+                                    parameterShouldMatchExactTypes,
+                                    detectionRules));
+                }
+            } else {
+                if (pendingKeywordName != null) {
+                    this.parameters.add(
+                            new DetectableParameter<>(
+                                    parameterType,
+                                    this.parameters.size(),
+                                    parameterShouldMatchExactTypes,
+                                    iValueFactory,
+                                    detectionRules,
+                                    positionMove,
+                                    pendingKeywordName,
+                                    pendingKeywordOptional));
+                } else {
+                    this.parameters.add(
+                            new DetectableParameter<>(
+                                    parameterType,
+                                    this.parameters.size(),
+                                    parameterShouldMatchExactTypes,
+                                    iValueFactory,
+                                    detectionRules,
+                                    positionMove));
+                }
+            }
+        } else {
+            if (pendingKeywordName != null) {
+                // Named parameter without .shouldBeDetectedAs() — store as a plain Parameter
+                // with keyword metadata so the engine can do keyword-name lookup / positional
+                // fallback without capturing a value.
                 this.parameters.add(
                         new Parameter<>(
                                 parameterType,
                                 this.parameters.size(),
                                 parameterShouldMatchExactTypes,
-                                detectionRules));
+                                detectionRules,
+                                pendingKeywordName,
+                                pendingKeywordOptional));
             } else {
                 this.parameters.add(
-                        new DetectableParameter<>(
+                        new Parameter<>(
                                 parameterType,
                                 this.parameters.size(),
                                 parameterShouldMatchExactTypes,
-                                iValueFactory,
-                                detectionRules,
-                                positionMove));
+                                List.of()));
             }
-        } else {
-            this.parameters.add(
-                    new Parameter<>(
-                            parameterType,
-                            this.parameters.size(),
-                            parameterShouldMatchExactTypes,
-                            List.of()));
+        }
+
+        if (pendingKeywordOptional && pendingKeywordName != null) {
+            this.optionalNamedParameterAdded = true;
         }
 
         this.parameterType = null;
@@ -539,6 +491,8 @@ final class DetectionRuleBuilderImpl<T>
         this.detectionRules = new LinkedList<>();
         this.positionMove = null;
         this.parameterShouldMatchExactTypes = false;
+        this.pendingKeywordName = null;
+        this.pendingKeywordOptional = false;
     }
 
     enum CapturedParameterScope {

--- a/engine/src/test/java/com/ibm/engine/rule/builder/DetectionRuleBuilderParameterOrderTest.java
+++ b/engine/src/test/java/com/ibm/engine/rule/builder/DetectionRuleBuilderParameterOrderTest.java
@@ -1,0 +1,123 @@
+/*
+ * Sonar Cryptography Plugin
+ * Copyright (C) 2024 PQCA
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ibm.engine.rule.builder;
+
+import static com.ibm.engine.detection.MethodMatcher.ANY;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
+
+import com.ibm.engine.model.context.PRNGContext;
+import com.ibm.engine.model.factory.ValueActionFactory;
+import com.ibm.engine.rule.IDetectionRule;
+import com.ibm.engine.rule.Parameter;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class DetectionRuleBuilderParameterOrderTest {
+
+    /**
+     * {@code withMethodParameter} after {@code withNamedMethodParameter} is illegal.
+     *
+     * <p>Python's calling convention requires all positional parameters to precede named ones. The
+     * builder enforces this at construction time.
+     */
+    @Test
+    void positionalAfterNamedThrows() {
+        assertThrowsExactly(
+                IllegalStateException.class,
+                () ->
+                        new DetectionRuleBuilder<>()
+                                .createDetectionRule()
+                                .forObjectTypes("com.example.Foo")
+                                .forMethods("bar")
+                                .withNamedMethodParameter("key", ANY)
+                                .withMethodParameter(ANY));
+    }
+
+    /**
+     * {@code withNamedMethodParameter} (required) after {@code withOptionalNamedMethodParameter} is
+     * illegal.
+     *
+     * <p>Python's calling convention requires required named parameters to precede optional ones.
+     * The builder enforces this at construction time.
+     */
+    @Test
+    void requiredNamedAfterOptionalNamedThrows() {
+        assertThrowsExactly(
+                IllegalStateException.class,
+                () ->
+                        new DetectionRuleBuilder<>()
+                                .createDetectionRule()
+                                .forObjectTypes("com.example.Foo")
+                                .forMethods("bar")
+                                .withOptionalNamedMethodParameter("first", ANY)
+                                .withNamedMethodParameter("second", ANY));
+    }
+
+    /** Required before optional is the valid order — no exception must be thrown. */
+    @Test
+    void requiredBeforeOptionalNamedIsValid() {
+        new DetectionRuleBuilder<>()
+                .createDetectionRule()
+                .forObjectTypes("com.example.Foo")
+                .forMethods("bar")
+                .shouldBeDetectedAs(new ValueActionFactory<>("bar"))
+                .withNamedMethodParameter("first", ANY)
+                .withOptionalNamedMethodParameter("second", ANY)
+                .buildForContext(new PRNGContext())
+                .inBundle(() -> "Test")
+                .withoutDependingDetectionRules();
+        // no exception → pass
+    }
+
+    /**
+     * {@code withNamedMethodParameter} followed by {@code addDependingDetectionRules} must retain
+     * the keyword name on the committed {@link Parameter}.
+     *
+     * <p>Regression test: previously the keyword name was silently dropped because {@code
+     * checkDetectionParameterState()} entered the {@code iValueFactory == null} branch and used the
+     * 4-arg {@code Parameter} constructor (which hard-codes {@code keywordName = null}).
+     */
+    @Test
+    void namedParameterWithDependingRulesRetainsKeywordName() {
+        IDetectionRule<Object> rule =
+                new DetectionRuleBuilder<>()
+                        .createDetectionRule()
+                        .forObjectTypes("com.example.Foo")
+                        .forMethods("bar")
+                        .withNamedMethodParameter("data", ANY)
+                        .addDependingDetectionRules(List.of())
+                        .buildForContext(new PRNGContext())
+                        .inBundle(() -> "Test")
+                        .withoutDependingDetectionRules();
+
+        List<Parameter<Object>> params =
+                (List<Parameter<Object>>) (List<?>) rule.nextDetectionRules(); // not needed here
+
+        // Reach the parameters through the DetectionRule
+        assertThat(rule).isInstanceOf(com.ibm.engine.rule.DetectionRule.class);
+        com.ibm.engine.rule.DetectionRule<Object> dr =
+                (com.ibm.engine.rule.DetectionRule<Object>) rule;
+        assertThat(dr.parameters()).hasSize(1);
+        assertThat(dr.parameters().get(0).getKeywordName())
+                .as("keyword name must survive addDependingDetectionRules")
+                .hasValue("data");
+    }
+}

--- a/python/src/test/files/rules/detection/named_parameters/FAllByKeywordTest.py
+++ b/python/src/test/files/rules/detection/named_parameters/FAllByKeywordTest.py
@@ -1,0 +1,10 @@
+from test.module import Foo
+
+# f(a="hello", b=42, c="yes") — all three arguments passed by keyword.
+# a satisfies withMethodParameter("str"): it is a positional rule parameter; the engine reads
+#   arguments.get(0) which is the RegularArgument a="hello" and unwraps its expression "hello"
+#   (a str literal) — type check passes.
+# b satisfies withNamedMethodParameter("b", "int") by keyword-name lookup "b".
+# c satisfies withOptionalNamedMethodParameter("c", "str") by keyword-name lookup "c".
+# → rule fires; c is captured.
+result = Foo.f(a="hello", b=42, c="yes")

--- a/python/src/test/files/rules/detection/named_parameters/FAllPositionalTest.py
+++ b/python/src/test/files/rules/detection/named_parameters/FAllPositionalTest.py
@@ -1,0 +1,8 @@
+from test.module import Foo
+
+# f("hello", 42, "yes") — all three arguments passed by position.
+# a satisfies withMethodParameter("str") at index 0.
+# b satisfies withNamedMethodParameter("b", "int") via positional fallback at index 1.
+# c satisfies withOptionalNamedMethodParameter("c", "str") via positional fallback at index 2.
+# → rule fires; c is captured.
+result = Foo.f("hello", 42, "yes")

--- a/python/src/test/files/rules/detection/named_parameters/FBCByKeywordCanonicalOrderTest.py
+++ b/python/src/test/files/rules/detection/named_parameters/FBCByKeywordCanonicalOrderTest.py
@@ -1,0 +1,8 @@
+from test.module import Foo
+
+# f("hello", b=42, c="yes") — a positional, b and c by keyword, canonical declaration order.
+# a satisfies withMethodParameter("str") at index 0.
+# b satisfies withNamedMethodParameter("b", "int") by keyword-name lookup "b".
+# c satisfies withOptionalNamedMethodParameter("c", "str") by keyword-name lookup "c".
+# → rule fires; c is captured.
+result = Foo.f("hello", b=42, c="yes")

--- a/python/src/test/files/rules/detection/named_parameters/FBCByKeywordReorderedTest.py
+++ b/python/src/test/files/rules/detection/named_parameters/FBCByKeywordReorderedTest.py
@@ -1,0 +1,9 @@
+from test.module import Foo
+
+# f("hello", c="yes", b=42) — a positional, b and c by keyword but in reversed order.
+# a satisfies withMethodParameter("str") at index 0.
+# b satisfies withNamedMethodParameter("b", "int") by keyword-name lookup "b" (found at index 2).
+# c satisfies withOptionalNamedMethodParameter("c", "str") by keyword-name lookup "c" (found at index 1).
+# The engine searches the whole argument list by name, so order does not matter.
+# → rule fires; c is captured.
+result = Foo.f("hello", c="yes", b=42)

--- a/python/src/test/files/rules/detection/named_parameters/FCAbsentAllKeywordTest.py
+++ b/python/src/test/files/rules/detection/named_parameters/FCAbsentAllKeywordTest.py
@@ -1,0 +1,8 @@
+from test.module import Foo
+
+# f(a="hello", b=42) — a and b by keyword, c absent.
+# a is positional in the rule; the engine reads arguments.get(0) = a="hello" and unwraps "hello".
+# b satisfies withNamedMethodParameter("b", "int") by keyword-name lookup "b".
+# c is optional and absent.
+# → rule fires; no c child in detection store.
+result = Foo.f(a="hello", b=42)

--- a/python/src/test/files/rules/detection/named_parameters/FCAbsentBByKeywordTest.py
+++ b/python/src/test/files/rules/detection/named_parameters/FCAbsentBByKeywordTest.py
@@ -1,0 +1,8 @@
+from test.module import Foo
+
+# f("hello", b=42) — a positional, b by keyword, c absent.
+# a satisfies withMethodParameter("str") at index 0.
+# b satisfies withNamedMethodParameter("b", "int") by keyword-name lookup "b".
+# c is optional and absent; findArgumentByKeyword("c", 2, ...) returns empty.
+# → rule fires; no c child in detection store.
+result = Foo.f("hello", b=42)

--- a/python/src/test/files/rules/detection/named_parameters/FCAbsentPositionalTest.py
+++ b/python/src/test/files/rules/detection/named_parameters/FCAbsentPositionalTest.py
@@ -1,0 +1,9 @@
+from test.module import Foo
+
+# f("hello", 42) — a and b present positionally, c absent.
+# a satisfies withMethodParameter("str") at index 0.
+# b satisfies withNamedMethodParameter("b", "int") via positional fallback at index 1.
+# c is declared withOptionalNamedMethodParameter so its absence does not suppress the rule.
+# findArgumentByKeyword("c", 2, ...) finds no keyword match and no positional arg at index 2.
+# → rule fires; no c child in detection store.
+result = Foo.f("hello", 42)

--- a/python/src/test/files/rules/detection/named_parameters/FCByKeywordTest.py
+++ b/python/src/test/files/rules/detection/named_parameters/FCByKeywordTest.py
@@ -1,0 +1,8 @@
+from test.module import Foo
+
+# f("hello", 42, c="yes") — a and b positional, c by keyword name.
+# a satisfies withMethodParameter("str") at index 0.
+# b satisfies withNamedMethodParameter("b", "int") via positional fallback at index 1.
+# c satisfies withOptionalNamedMethodParameter("c", "str") by keyword-name lookup "c".
+# → rule fires; c is captured.
+result = Foo.f("hello", 42, c="yes")

--- a/python/src/test/files/rules/detection/named_parameters/FExtraUnknownKwargTest.py
+++ b/python/src/test/files/rules/detection/named_parameters/FExtraUnknownKwargTest.py
@@ -1,0 +1,9 @@
+from test.module import Foo
+
+# f("hello", 42, "yes", d=0) — matching args plus one completely unknown keyword argument.
+# a satisfies withMethodParameter("str") at index 0.
+# b satisfies withNamedMethodParameter("b", "int") via positional fallback at index 1.
+# c satisfies withOptionalNamedMethodParameter("c", "str") via positional fallback at index 2.
+# d=0 sits at index 3; no rule parameter ever references it, so it is silently ignored.
+# → rule fires; c is captured.
+result = Foo.f("hello", 42, "yes", d=0)

--- a/python/src/test/files/rules/detection/named_parameters/FNegativeAAbsentTest.py
+++ b/python/src/test/files/rules/detection/named_parameters/FNegativeAAbsentTest.py
@@ -1,0 +1,6 @@
+from test.module import Foo
+
+# f(b=42) — only b is provided as a keyword; a's positional slot is missing entirely.
+# arguments.size() = 1 < minArgs = 2, so the arity gate rejects the call.
+# → rule does NOT fire.
+result = Foo.f(b=42)

--- a/python/src/test/files/rules/detection/named_parameters/FNegativeBAbsentTest.py
+++ b/python/src/test/files/rules/detection/named_parameters/FNegativeBAbsentTest.py
@@ -1,0 +1,7 @@
+from test.module import Foo
+
+# f("hello") — only a present; b (required named) is absent.
+# minArgs = 2 (positional a + required named b); arguments.size() = 1 < 2.
+# The arity gate rejects the call before any type checks run.
+# → rule does NOT fire.
+result = Foo.f("hello")

--- a/python/src/test/files/rules/detection/named_parameters/FNegativeDictUnpackTest.py
+++ b/python/src/test/files/rules/detection/named_parameters/FNegativeDictUnpackTest.py
@@ -1,0 +1,9 @@
+from test.module import Foo
+
+d = {"b": 42, "c": True}
+
+# f("hello", **d) — dict-unpacking argument; contents cannot be statically inspected.
+# The engine sees a non-RegularArgument in the argument list and rejects the call immediately
+# in the unpacking-argument gate.
+# → rule does NOT fire.
+result = Foo.f("hello", **d)

--- a/python/src/test/files/rules/detection/named_parameters/FNegativeWrongTypeATest.py
+++ b/python/src/test/files/rules/detection/named_parameters/FNegativeWrongTypeATest.py
@@ -1,0 +1,7 @@
+from test.module import Foo
+
+# f(42, 42) — a is an int literal but the rule declares withMethodParameter("str").
+# The positional type-check loop resolves arguments.get(0) as int and rejects it against "str".
+# The entire rule is suppressed — not just parameter a.
+# → rule does NOT fire.
+result = Foo.f(42, 42)

--- a/python/src/test/files/rules/detection/named_parameters/FNegativeWrongTypeBTest.py
+++ b/python/src/test/files/rules/detection/named_parameters/FNegativeWrongTypeBTest.py
@@ -1,0 +1,7 @@
+from test.module import Foo
+
+# f("hello", "42") — b is a str literal but the rule declares withNamedMethodParameter("b","int").
+# b is found via positional fallback at index 1; the named-parameter type-check resolves "42" as
+# str and rejects it against "int". Because b is required (not optional), the rule returns early.
+# → rule does NOT fire.
+result = Foo.f("hello", "42")

--- a/python/src/test/java/com/ibm/plugin/rules/detection/NamedParametersTest.java
+++ b/python/src/test/java/com/ibm/plugin/rules/detection/NamedParametersTest.java
@@ -1,0 +1,354 @@
+/*
+ * Sonar Cryptography Plugin
+ * Copyright (C) 2024 PQCA
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ibm.plugin.rules.detection;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.ibm.engine.detection.DetectionStore;
+import com.ibm.engine.model.AlgorithmParameter;
+import com.ibm.engine.model.IValue;
+import com.ibm.engine.model.ValueAction;
+import com.ibm.engine.model.context.DigestContext;
+import com.ibm.engine.model.factory.AlgorithmParameterFactory;
+import com.ibm.engine.model.factory.ValueActionFactory;
+import com.ibm.engine.rule.IDetectionRule;
+import com.ibm.engine.rule.builder.DetectionRuleBuilder;
+import com.ibm.mapper.model.INode;
+import com.ibm.plugin.TestBase;
+import java.util.List;
+import javax.annotation.Nonnull;
+import org.junit.jupiter.api.Test;
+import org.sonar.plugins.python.api.PythonCheck;
+import org.sonar.plugins.python.api.PythonVisitorContext;
+import org.sonar.plugins.python.api.symbols.Symbol;
+import org.sonar.plugins.python.api.tree.Tree;
+import org.sonar.python.checks.utils.PythonCheckVerifier;
+
+/**
+ * Tests for a detection rule modelling {@code test.module.Foo.f(a, b, c)} with the signature:
+ *
+ * <pre>
+ *   .withMethodParameter("str")                    // a — positional, required, type str  (index 0)
+ *   .withNamedMethodParameter("b", "int")          // b — named, required,    type int  (index 1)
+ *   .withOptionalNamedMethodParameter("c", "str")  // c — named, optional,    type str  (index 2)
+ * </pre>
+ *
+ * <p>{@code c} is declared as {@code str} so its value (a plain string literal like {@code "yes"})
+ * can be reliably resolved and captured by {@link AlgorithmParameterFactory}. The parameter shape
+ * ({@code withMethodParameter} → {@code withNamedMethodParameter} → {@code
+ * withOptionalNamedMethodParameter}) is what drives the test coverage; the exact type of {@code c}
+ * is incidental.
+ *
+ * <p>The {@code c} parameter is captured as an {@link AlgorithmParameter} child so tests can verify
+ * whether it was resolved.
+ *
+ * <h2>Positive variants — c child expected (rule fires, c present)</h2>
+ *
+ * <ul>
+ *   <li>{@code f("hello", 42, "yes")} — all three positional → c captured
+ *   <li>{@code f("hello", 42, c="yes")} — a/b positional, c by keyword → c captured
+ *   <li>{@code f("hello", b=42, c="yes")} — a positional, b/c by keyword, canonical order → c
+ *       captured
+ *   <li>{@code f("hello", c="yes", b=42)} — a positional, b/c by keyword, reordered → c captured
+ *   <li>{@code f(a="hello", b=42, c="yes")} — all by keyword (positional slot for a) → c captured
+ *   <li>{@code f("hello", 42, "yes", d=0)} — extra unknown kwarg silently ignored → c captured
+ * </ul>
+ *
+ * <h2>Positive variants — c child absent (rule fires, c optional and missing)</h2>
+ *
+ * <ul>
+ *   <li>{@code f("hello", 42)} — a/b present, c absent → no c child
+ *   <li>{@code f("hello", b=42)} — a positional, b by keyword, c absent → no c child
+ *   <li>{@code f(a="hello", b=42)} — a/b by keyword, c absent → no c child
+ * </ul>
+ *
+ * <h2>Negative variants (rule must NOT fire)</h2>
+ *
+ * <ul>
+ *   <li>{@code f("hello")} — b required but absent → no detection
+ *   <li>{@code f(42, 42)} — a has wrong type (int, not str) → no detection
+ *   <li>{@code f("hello", "42")} — b has wrong type (str, not int) → no detection
+ *   <li>{@code f(b=42)} — a positional slot absent → no detection
+ *   <li>{@code f(**d)} — dict-unpacking; contents not statically inspectable → no detection
+ * </ul>
+ */
+class NamedParametersTest extends TestBase {
+
+    private static final String BASE_PATH = "src/test/files/rules/detection/named_parameters/";
+
+    /**
+     * Rule under test:
+     *
+     * <pre>
+     *   test.module.Foo.f(a: str, b: int, c: str = ...)
+     * </pre>
+     *
+     * <ul>
+     *   <li>{@code a} — positional required, type {@code str}; matched at index 0, captured as the
+     *       root {@link ValueAction}
+     *   <li>{@code b} — named required, type {@code int}; matched at index 1 (by name or positional
+     *       fallback); not directly captured (no shouldBeDetectedAs on b)
+     *   <li>{@code c} — named optional, type {@code str}; matched at index 2 (by name or positional
+     *       fallback); captured as an {@link AlgorithmParameter} child of the root
+     * </ul>
+     */
+    private static final IDetectionRule<Tree> RULE =
+            new DetectionRuleBuilder<Tree>()
+                    .createDetectionRule()
+                    .forObjectTypes("test.module.Foo")
+                    .forMethods("f")
+                    .shouldBeDetectedAs(new ValueActionFactory<>("f"))
+                    .withMethodParameter("str")
+                    .withNamedMethodParameter("b", "int")
+                    .withOptionalNamedMethodParameter("c", "str")
+                    .shouldBeDetectedAs(
+                            new AlgorithmParameterFactory<>(AlgorithmParameter.Kind.ANY))
+                    .asChildOfParameterWithId(2)
+                    .buildForContext(new DigestContext())
+                    .inBundle(() -> "Test")
+                    .withoutDependingDetectionRules();
+
+    /**
+     * Flipped by each test before calling {@link PythonCheckVerifier#verifyNoIssue} to tell {@link
+     * #asserts} whether the {@code c} parameter child is expected.
+     */
+    private boolean expectCChild = false;
+
+    NamedParametersTest() {
+        super(List.of(RULE));
+    }
+
+    // -------------------------------------------------------------------------
+    // Positive tests — c child expected
+    // -------------------------------------------------------------------------
+
+    /**
+     * {@code f("hello", 42, "yes")} — a, b, c all passed positionally.
+     *
+     * <p>Fires because: a satisfies {@code withMethodParameter("str")} at index 0; b satisfies
+     * {@code withNamedMethodParameter("b","int")} via positional fallback at index 1; c satisfies
+     * {@code withOptionalNamedMethodParameter("c","str")} via positional fallback at index 2.
+     */
+    @Test
+    void testAllPositional() {
+        expectCChild = true;
+        PythonCheckVerifier.verifyNoIssue(BASE_PATH + "FAllPositionalTest.py", this);
+    }
+
+    /**
+     * {@code f("hello", 42, c="yes")} — a and b positional, c by keyword.
+     *
+     * <p>Fires because: a and b matched positionally; c matched by keyword name {@code "c"}.
+     */
+    @Test
+    void testCByKeyword() {
+        expectCChild = true;
+        PythonCheckVerifier.verifyNoIssue(BASE_PATH + "FCByKeywordTest.py", this);
+    }
+
+    /**
+     * {@code f("hello", b=42, c="yes")} — a positional, b and c by keyword, canonical order.
+     *
+     * <p>Fires because: a matched positionally; b matched by keyword name {@code "b"}; c matched by
+     * keyword name {@code "c"}.
+     */
+    @Test
+    void testBCByKeywordCanonicalOrder() {
+        expectCChild = true;
+        PythonCheckVerifier.verifyNoIssue(BASE_PATH + "FBCByKeywordCanonicalOrderTest.py", this);
+    }
+
+    /**
+     * {@code f("hello", c="yes", b=42)} — a positional, b and c by keyword, reordered.
+     *
+     * <p>Fires because: a matched positionally; b and c each matched by keyword name regardless of
+     * their physical order in the argument list.
+     */
+    @Test
+    void testBCByKeywordReordered() {
+        expectCChild = true;
+        PythonCheckVerifier.verifyNoIssue(BASE_PATH + "FBCByKeywordReorderedTest.py", this);
+    }
+
+    /**
+     * {@code f(a="hello", b=42, c="yes")} — all three by keyword; a resolved via the positional
+     * slot at index 0.
+     *
+     * <p>Fires because: a is a positional rule parameter (no keyword name). The engine reads {@code
+     * arguments.get(0)} which is the {@code RegularArgument a="hello"}, unwraps its expression
+     * {@code "hello"} (a str literal), and the type check for {@code "str"} passes. b is matched by
+     * keyword name {@code "b"} and c by keyword name {@code "c"}.
+     */
+    @Test
+    void testAllByKeyword() {
+        expectCChild = true;
+        PythonCheckVerifier.verifyNoIssue(BASE_PATH + "FAllByKeywordTest.py", this);
+    }
+
+    /**
+     * {@code f("hello", 42, "yes", d=0)} — three matching args plus one extra unknown keyword.
+     *
+     * <p>Fires because: all required parameters are satisfied; the extra keyword argument {@code
+     * d=0} sits beyond index 2 and is never referenced by any rule parameter, so it is silently
+     * ignored. c is captured via positional fallback at index 2.
+     */
+    @Test
+    void testExtraUnknownKwarg() {
+        expectCChild = true;
+        PythonCheckVerifier.verifyNoIssue(BASE_PATH + "FExtraUnknownKwargTest.py", this);
+    }
+
+    // -------------------------------------------------------------------------
+    // Positive tests — c child must be ABSENT
+    // -------------------------------------------------------------------------
+
+    /**
+     * {@code f("hello", 42)} — a and b present, c absent.
+     *
+     * <p>Fires because: required parameters a and b are satisfied; c is optional so its absence
+     * does not suppress the rule. No c child in the detection store.
+     */
+    @Test
+    void testCAbsentPositional() {
+        expectCChild = false;
+        PythonCheckVerifier.verifyNoIssue(BASE_PATH + "FCAbsentPositionalTest.py", this);
+    }
+
+    /**
+     * {@code f("hello", b=42)} — a positional, b by keyword, c absent.
+     *
+     * <p>Fires because: a satisfied positionally; b satisfied by keyword; c is optional and absent.
+     */
+    @Test
+    void testCAbsentBByKeyword() {
+        expectCChild = false;
+        PythonCheckVerifier.verifyNoIssue(BASE_PATH + "FCAbsentBByKeywordTest.py", this);
+    }
+
+    /**
+     * {@code f(a="hello", b=42)} — a and b by keyword, c absent.
+     *
+     * <p>Fires because: a resolved at index 0, b by keyword; c is optional and absent.
+     */
+    @Test
+    void testCAbsentAllKeyword() {
+        expectCChild = false;
+        PythonCheckVerifier.verifyNoIssue(BASE_PATH + "FCAbsentAllKeywordTest.py", this);
+    }
+
+    // -------------------------------------------------------------------------
+    // Negative tests — rule must NOT fire
+    // -------------------------------------------------------------------------
+
+    /**
+     * {@code f("hello")} — only a present; b (required named) is absent.
+     *
+     * <p>Does NOT fire because: the engine counts minArgs = 2 (a + b); the call has 1 argument
+     * which is less than minArgs, so the rule is rejected in the arity gate.
+     */
+    @Test
+    void testNegativeBAbsent() {
+        PythonCheckVerifier.verifyNoIssue(BASE_PATH + "FNegativeBAbsentTest.py", this);
+    }
+
+    /**
+     * {@code f(42, 42)} — a has wrong type (int literal instead of str).
+     *
+     * <p>Does NOT fire because: the positional type-check gate resolves the argument at index 0 as
+     * {@code int} and rejects it against the declared type {@code "str"}, suppressing the entire
+     * rule.
+     */
+    @Test
+    void testNegativeWrongTypeA() {
+        PythonCheckVerifier.verifyNoIssue(BASE_PATH + "FNegativeWrongTypeATest.py", this);
+    }
+
+    /**
+     * {@code f("hello", "42")} — b has wrong type (str literal instead of int).
+     *
+     * <p>Does NOT fire because: the required-named-parameter resolution finds b via positional
+     * fallback at index 1, then the named-parameter type check rejects {@code "42"} (a str) against
+     * the declared type {@code "int"}, and since b is required the rule returns early.
+     */
+    @Test
+    void testNegativeWrongTypeB() {
+        PythonCheckVerifier.verifyNoIssue(BASE_PATH + "FNegativeWrongTypeBTest.py", this);
+    }
+
+    /**
+     * {@code f(b=42)} — a's positional slot has no usable value; a is required.
+     *
+     * <p>Does NOT fire because: arguments.size() = 1 which is less than minArgs = 2, so the arity
+     * gate rejects the call before the type checks run.
+     */
+    @Test
+    void testNegativeAAbsent() {
+        PythonCheckVerifier.verifyNoIssue(BASE_PATH + "FNegativeAAbsentTest.py", this);
+    }
+
+    /**
+     * {@code f(**d)} — dict-unpacking argument; contents not statically inspectable.
+     *
+     * <p>Does NOT fire because: the engine detects a non-{@link
+     * org.sonar.plugins.python.api.tree.RegularArgument} in the argument list and rejects the call
+     * immediately.
+     */
+    @Test
+    void testNegativeDictUnpack() {
+        PythonCheckVerifier.verifyNoIssue(BASE_PATH + "FNegativeDictUnpackTest.py", this);
+    }
+
+    // -------------------------------------------------------------------------
+    // asserts — called once per finding by TestBase.update()
+    // -------------------------------------------------------------------------
+
+    @Override
+    public void asserts(
+            int findingId,
+            @Nonnull DetectionStore<PythonCheck, Tree, Symbol, PythonVisitorContext> detectionStore,
+            @Nonnull List<INode> nodes) {
+
+        // Root detection: the ValueAction produced by shouldBeDetectedAs(new
+        // ValueActionFactory<>("f"))
+        assertThat(detectionStore.getDetectionValues()).hasSize(1);
+        assertThat(detectionStore.getDetectionValueContext()).isInstanceOf(DigestContext.class);
+
+        IValue<Tree> rootValue = detectionStore.getDetectionValues().get(0);
+        assertThat(rootValue).isInstanceOf(ValueAction.class);
+        assertThat(rootValue.asString()).isEqualTo("f");
+
+        // Child detection store for c, present only when expectCChild = true
+        DetectionStore<PythonCheck, Tree, Symbol, PythonVisitorContext> cStore =
+                getStoreOfValueType(AlgorithmParameter.class, detectionStore.getChildren());
+        if (expectCChild) {
+            assertThat(cStore)
+                    .as("expected a child detection store for c but found none")
+                    .isNotNull();
+            assertThat(cStore.getDetectionValues()).hasSize(1);
+            IValue<Tree> cValue = cStore.getDetectionValues().get(0);
+            assertThat(cValue).isInstanceOf(AlgorithmParameter.class);
+            assertThat(cValue.asString()).isEqualTo("yes");
+        } else {
+            assertThat(cStore)
+                    .as("expected no child detection store for c but one was produced")
+                    .isNull();
+        }
+    }
+}


### PR DESCRIPTION
# Add `with[Optional]NamedMethodParameter` to the detection rule DSL

**Engine · Python · keyword-argument-aware parameter matching**

## Motivation

Python callers routinely pass arguments out of order using keyword syntax, and routinely omit optional parameters entirely:

```python
SHA512.new(truncate="256")                                       # data omitted
SHA512.new(truncate="256", data=b"msg")                          # reordered
PBKDF2HMAC(iterations=480000, algorithm=SHA256(), salt=s, length=32)  # fully reordered
```

The existing `withMethodParameter(type)` method is purely positional: it reads argument *n* for parameter *n* and requires an exact argument count enforced by `MethodMatcher`. It cannot handle reordered arguments, omitted optional parameters, or the keyword-argument call style that is idiomatic in Python cryptography APIs. 

## Description

Add support for named and optional named method parameters in detection rules for the Python engine.

### New builder methods

Two new methods are added to the `DetectionRuleBuilder` fluent API:

| Method | Signature | Behaviour |
|---|---|---|
| `withNamedMethodParameter` | `(String name, String type)` | Declares a **required** named parameter. The engine resolves it first by keyword-argument name, then falls back to the positional index if the argument at that index carries no keyword marker. If the parameter is absent or its type does not match the declaration, the rule does **not** fire. |
| `withOptionalNamedMethodParameter` | `(String name, String type)` | Declares an **optional** named parameter. Resolution follows the same keyword-name → positional-fallback order. If the parameter is absent the rule still fires; if it is present but the type does not match, that single parameter is silently skipped. |

The pre-existing `withMethodParameter` and `withMethodParameterMatchExactType` are **fully backward-compatible**: rules that use only positional parameters are unaffected — the builder takes the same code path as before and the `MethodMatcher` is constructed with the same type list as it always was. The only addition is a guard that throws `IllegalStateException` if a positional-parameter call is made _after_ a named-parameter call, enforcing Python's calling-convention order at construction time.

**Ordering constraints** (enforced at construction time):

- All `withMethodParameter` / `withMethodParameterMatchExactType` calls must precede any `withNamedMethodParameter` / `withOptionalNamedMethodParameter` call. Violating this throws `IllegalStateException`.
- All required named parameters (`withNamedMethodParameter`) must precede optional ones (`withOptionalNamedMethodParameter`). Violating this also throws `IllegalStateException`.

**Example rule definition:**

```java
new DetectionRuleBuilder<Tree>()
    .createDetectionRule()
    .forObjectTypes("test.module.Foo")
    .forMethods("f")
    .shouldBeDetectedAs(new ValueActionFactory<>("f"))
    .withMethodParameter("str")                           // a — positional, required
    .withNamedMethodParameter("b", "int")                 // b — named, required
    .withOptionalNamedMethodParameter("c", "str")         // c — named, optional
    .shouldBeDetectedAs(new AlgorithmParameterFactory<>(AlgorithmParameter.Kind.ANY))
    .asChildOfParameterWithId(2)
    .buildForContext(new DigestContext())
    .inBundle(() -> "Test")
    .withoutDependingDetectionRules();
```

### Engine changes (`PythonDetectionEngine`)

When a rule contains at least one named parameter:

1. The `MethodMatcher` is constructed **without** a type list so the matcher accepts any arity call and delegates structural validation to the extraction loop.
2. Before emitting any detection, a set of **pre-flight gates** runs:
   - **Unpacking gate** — rejects calls with `*args` / `**kwargs` arguments whose contents cannot be statically inspected.
   - **Arity gate** — rejects calls where `arguments.size() < minArgs` (`minArgs` = positional params + required named params).
   - **Required-named-present gate** — rejects calls where a required named parameter cannot be resolved (neither by keyword name nor by positional fallback).
   - **Positional type-check gate** — rejects calls where a positional parameter's resolved type does not match its declaration.
3. A new helper `findArgumentByKeyword(name, positionalIndex, arguments)` resolves each named parameter: keyword-name match first, positional fallback second (only when the argument at that index carries no keyword marker itself).
4. The repeated extraction logic is extracted into `processParameterExpression` to avoid duplication between the positional and named paths.
5. `checkSymbolTraceState` is extracted from `checkCurrentIndexState` so the symbol-trace check can be reused on the named-parameter path without re-running the arity guard.

---

### Test: `NamedParametersTest`

Located at [`python/src/test/java/com/ibm/plugin/rules/detection/NamedParametersTest.java`](python/src/test/java/com/ibm/plugin/rules/detection/NamedParametersTest.java).

The test rule models `test.module.Foo.f(a: str, b: int, c: str = …)` — one positional-required, one named-required, one named-optional parameter.

The optional parameter `c` (type `str`) is captured as an `AlgorithmParameter` child so each test can assert whether it was resolved.

#### Tests where the rule fires

| Test method | Python call | `c` child captured | Why the rule fires |
|---|---|---|---|
| `testAllPositional` | `f("hello", 42, "yes")` | ✅ | `a` at index 0, `b` via positional fallback at index 1, `c` via positional fallback at index 2 |
| `testCByKeyword` | `f("hello", 42, c="yes")` | ✅ | `a`/`b` positional, `c` matched by keyword name `"c"` |
| `testBCByKeywordCanonicalOrder` | `f("hello", b=42, c="yes")` | ✅ | `a` positional, `b` and `c` matched by keyword name in declaration order |
| `testBCByKeywordReordered` | `f("hello", c="yes", b=42)` | ✅ | `a` positional, `b` and `c` matched by keyword name regardless of physical argument order |
| `testAllByKeyword` | `f(a="hello", b=42, c="yes")` | ✅ | `a` is a positional rule parameter — engine reads `arguments.get(0)` = `a="hello"` and unwraps `"hello"`; `b` and `c` by keyword name |
| `testExtraUnknownKwarg` | `f("hello", 42, "yes", d=0)` | ✅ | All required params satisfied; `d=0` at index 3 is never referenced and silently ignored |
| `testCAbsentPositional` | `f("hello", 42)` | ❌ | `a` and `b` satisfied; `c` is optional and absent — rule still fires, no `c` child |
| `testCAbsentBByKeyword` | `f("hello", b=42)` | ❌ | `a` positional, `b` by keyword; `c` is optional and absent — rule still fires, no `c` child |
| `testCAbsentAllKeyword` | `f(a="hello", b=42)` | ❌ | `a` at index 0, `b` by keyword; `c` is optional and absent — rule still fires, no `c` child |

#### Tests where the rule does NOT fire

| Test method | Python call | Why the rule does not fire |
|---|---|---|
| `testNegativeBAbsent` | `f("hello")` | `arguments.size() = 1 < minArgs = 2` — arity gate rejects before any type check |
| `testNegativeWrongTypeA` | `f(42, 42)` | Positional type-check gate resolves `arguments[0]` as `int`, rejects against declared type `"str"` |
| `testNegativeWrongTypeB` | `f("hello", "42")` | `b` found via positional fallback at index 1; named-parameter type check resolves `"42"` as `str`, rejects against `"int"`; because `b` is required the rule returns early |
| `testNegativeAAbsent` | `f(b=42)` | `arguments.size() = 1 < minArgs = 2` — arity gate rejects (the single argument is keyword `b`, leaving the positional slot for `a` empty) |
| `testNegativeDictUnpack` | `f("hello", **d)` | Unpacking gate detects a non-`RegularArgument` and rejects the call immediately |

---

### Additional test: `DetectionRuleBuilderParameterOrderTest`

Located at [`engine/src/test/java/com/ibm/engine/rule/builder/DetectionRuleBuilderParameterOrderTest.java`](engine/src/test/java/com/ibm/engine/rule/builder/DetectionRuleBuilderParameterOrderTest.java).

Verifies that the ordering constraints are enforced at construction time (`positionalAfterNamedThrows`, `requiredNamedAfterOptionalNamedThrows`, `requiredBeforeOptionalNamedIsValid`) and that a named parameter's keyword name is not silently dropped when `.addDependingDetectionRules()` is chained (`namedParameterWithDependingRulesRetainsKeywordName`).

